### PR TITLE
Improve BigQuery error log output

### DIFF
--- a/plugins/patriot-gcp/lib/patriot_gcp/ext/bigquery.rb
+++ b/plugins/patriot-gcp/lib/patriot_gcp/ext/bigquery.rb
@@ -70,8 +70,8 @@ module PatriotGCP
           state = response["status"]["state"]
 
           if state == 'DONE'
-            if response["status"]["errorResult"]
-              raise BigQueryException, "upload failed: #{response['status']['errorResult']}"
+            if response["status"]["errors"]
+              raise BigQueryException, "upload failed: #{response['status']['errors']}"
             else
               return response["statistics"]
             end
@@ -101,10 +101,11 @@ module PatriotGCP
 
         begin
           job_id = JSON.parse(result.response.body)['jobReference']['jobId']
-          return _poll(bq_client, api_client, auth_client, project_id, job_id)
         rescue
-          raise BigQueryException, "upload failed: #{result.response.body}"
+          raise BigQueryException, "failed to register job: #{result.response.body}"
         end
+
+        return _poll(bq_client, api_client, auth_client, project_id, job_id)
       end
 
 

--- a/plugins/patriot-gcp/spec/patriot_gcp/ext/bigquery_spec.rb
+++ b/plugins/patriot-gcp/spec/patriot_gcp/ext/bigquery_spec.rb
@@ -57,6 +57,76 @@ describe PatriotGCP::Ext::BigQuery do
   end
 
 
+  it "raises BigQueryException when getting error from api" do
+    api_client_mock = double('api-client-mock')
+    allow(api_client_mock).to receive(:discovered_api).with(
+      'bigquery', 'v2'
+    ){
+      double(
+        nil, 
+        {:jobs => double(
+          nil,
+          {:get => "GET", :insert => "INSERT"}
+        )}
+      )
+    }
+
+    allow(api_client_mock).to receive(:execute).with(
+      hash_including(
+        :api_method => 'INSERT',
+        :parameters => {
+          'projectId' => 'test-project',
+          'uploadType' => 'multipart'
+        }
+      )
+    ){
+      double(
+        nil,
+        {:response => double(
+          nil, 
+          {
+            :body => '{"status": {
+              "state": "DONE"
+              "errorResult"=>{
+                "reason"=>"invalid",
+                "message"=>"Too many errors encountered. Limit is: 0."
+              },
+              "errors"=>[
+                {
+                  "reason"=>"invalid",
+                  "location"=>"File: 0 / Line:100 / Field:6",
+                  "message"=>"Invalid argument: 1,234.0"
+                },
+                {
+                  "reason"=>"invalid",
+                  "message"=>"Too many errors encountered. Limit is: 0."
+                }
+              ]
+            }}'
+          }
+        )}
+      )
+    }
+      
+    allow(Google::APIClient).to receive(:new).and_return(api_client_mock)
+    expect(api_client_mock).to receive(:execute).with(hash_including(:api_method => "INSERT")).once
+    expect(api_client_mock).to receive(:execute).with(hash_including(:api_method => "GET")).never
+    expect {
+      bq_load(File.join(SAMPLE_DIR, "hive_result.txt"),
+              '/path/to/keyfile',
+              'key_pass',
+              'test-account@developer.gserviceaccount.com',
+              'test-project',
+              'test-dataset',
+              'test-table',
+              'field1',
+              options={'fieldDelimiter' => '\t',
+                       'writeDisposition' => 'WRITE_APPEND',
+                       'allowLargeResults' => true})
+    }.to raise_error(BigQueryException)
+  end
+
+
   it "loads data to bigquery but fails to register a job" do
     api_client_mock = double('api-client-mock')
     allow(api_client_mock).to receive(:discovered_api).with('bigquery', 'v2'){
@@ -110,7 +180,7 @@ describe PatriotGCP::Ext::BigQuery do
                                     {:body => '{"jobReference": {"jobId": "job_id01"}}'})})
     }
 
-    # response contains an error result
+    # response contains errors
     allow(api_client_mock).to receive(:execute).with(hash_including(:api_method => 'GET',
                                                                     :parameters => {
                                                                         'projectId' => 'test-project',
@@ -118,7 +188,7 @@ describe PatriotGCP::Ext::BigQuery do
                                                                     })){
         double(nil,
                {:response => double(nil,
-                                    {:body => '{"status": {"state": "DONE", "errorResult": "test error"},
+                                    {:body => '{"status": {"state": "DONE", "errors": ["test error"]},
                                                 "statistics": {"insertline": 1}}'})})
     }
 


### PR DESCRIPTION
1. Change output source from status.errorResult to status.errors
   to get more information
2. Correct error message
3. Raise other exceptions ( _poll, _bq_load )