### PR TITLE
load_to_bigquery: Enable to set properties at inifile or pbc

### DIFF
--- a/plugins/patriot-gcp/lib/patriot_gcp/command/load_to_bigquery.rb
+++ b/plugins/patriot-gcp/lib/patriot_gcp/command/load_to_bigquery.rb
@@ -4,17 +4,32 @@ module PatriotGCP
       declare_command_name :load_to_bigquery
       include PatriotGCP::Ext::BigQuery
 
-      command_attr :inifile, :dataset, :table, :schema, :options, :input_file, :name_suffix, :polling_interval
+      command_attr :inifile, :project_id, :dataset, :table, :schema, :options, :input_file, :name_suffix, :polling_interval
 
       class BigQueryException < Exception; end
       class GoogleCloudPlatformException < Exception; end
 
       def job_id
-        job_id = "#{command_name}_#{@dataset}_#{@table}"
+        job_id = "#{command_name}_#{@project_id}_#{@dataset}_#{@table}"
         job_id = "#{job_id}_#{@name_suffix}" unless @name_suffix.nil?
         return job_id
       end
 
+      # @see Patriot::Command::Base#configure
+      def configure
+        ini = IniFile.load(@inifile)
+        if ini.nil?
+          raise Exception, "inifile not found"
+        end
+
+        @service_account  = ini["gcp"]["service_account"]
+        @private_key      = ini["gcp"]["private_key"]
+        @key_pass         = ini["gcp"]["key_pass"]
+        @project_id     ||= ini["bigquery"]["project_id"]
+        @dataset        ||= ini["bigquery"]["dataset"]
+
+        return self
+      end
 
       def execute
         @logger.info "start load_to_bigquery"
@@ -28,28 +43,18 @@ module PatriotGCP
           return
         end
 
-        ini = IniFile.load(@inifile)
-        if ini.nil?
-          raise Exception, "inifile not found"
-        end
-
-        service_account = ini["gcp"]["service_account"]
-        private_key = ini["gcp"]["private_key"]
-        key_pass = ini["gcp"]["key_pass"]
-        project_id = ini["bigquery"]["project_id"]
-
-        if service_account.nil? or private_key.nil?
+        if @service_account.nil? or @private_key.nil?
           raise GoogleCloudPlatformException, "configuration for GCP is not enough."
-        elsif project_id.nil?
+        elsif @project_id.nil? or @dataset.nil?
           raise BigQueryException, "configuration for BigQuery is not enough."
         end
 
         @logger.info "start uploading"
         stat_info = bq_load(@input_file,
-                            private_key,
-                            key_pass,
-                            service_account,
-                            project_id,
+                            @private_key,
+                            @key_pass,
+                            @service_account,
+                            @project_id,
                             @dataset,
                             @table,
                             @schema,

--- a/plugins/patriot-gcp/spec/config/test-bigquery-with-dataset.ini
+++ b/plugins/patriot-gcp/spec/config/test-bigquery-with-dataset.ini
@@ -1,0 +1,7 @@
+[gcp]
+service_account = test-account@developer.gserviceaccount.com
+private_key = /path/to/keyfile
+key_pass = key_pass
+
+[bigquery]
+dataset = test-dataset

--- a/plugins/patriot-gcp/spec/config/test-bigquery-with-project_id-and-dataset.ini
+++ b/plugins/patriot-gcp/spec/config/test-bigquery-with-project_id-and-dataset.ini
@@ -1,0 +1,8 @@
+[gcp]
+service_account = test-account@developer.gserviceaccount.com
+private_key = /path/to/keyfile
+key_pass = key_pass
+
+[bigquery]
+project_id = test-project
+dataset = test-dataset

--- a/plugins/patriot-gcp/spec/config/test-bigquery-with-project_id.ini
+++ b/plugins/patriot-gcp/spec/config/test-bigquery-with-project_id.ini
@@ -1,0 +1,7 @@
+[gcp]
+service_account = test-account@developer.gserviceaccount.com
+private_key = /path/to/keyfile
+key_pass = key_pass
+
+[bigquery]
+project_id = test-project

--- a/plugins/patriot-gcp/spec/config/test-bigquery-without-project_id-and-dataset.ini
+++ b/plugins/patriot-gcp/spec/config/test-bigquery-without-project_id-and-dataset.ini
@@ -1,0 +1,6 @@
+[gcp]
+service_account = test-account@developer.gserviceaccount.com
+private_key = /path/to/keyfile
+key_pass = key_pass
+
+[bigquery]

--- a/plugins/patriot-gcp/spec/patriot_gcp/command/load_to_bigquery_spec.rb
+++ b/plugins/patriot-gcp/spec/patriot_gcp/command/load_to_bigquery_spec.rb
@@ -8,7 +8,7 @@ describe PatriotGCP::Command::LoadToBigQueryCommand do
     @config = config_for_test
   end 
 
-  it "sholud work" do
+  it "should work" do
     allow_any_instance_of(PatriotGCP::Ext::BigQuery).to receive(:bq_load)
     cmd = new_command(PatriotGCP::Command::LoadToBigQueryCommand) do  
       inifile path_to_test_config('test-bigquery.ini')
@@ -22,12 +22,10 @@ describe PatriotGCP::Command::LoadToBigQueryCommand do
       polling_interval 30
     end 
     cmd = cmd.build[0]
-    cmd = cmd.to_job.to_command(@config)
-
     cmd.execute
   end 
 
-  it "sholud work without arbitrary parameters" do
+  it "should work without arbitrary parameters" do
     allow_any_instance_of(PatriotGCP::Ext::BigQuery).to receive(:bq_load)
     cmd = new_command(PatriotGCP::Command::LoadToBigQueryCommand) do
       inifile path_to_test_config('test-bigquery.ini')
@@ -37,12 +35,10 @@ describe PatriotGCP::Command::LoadToBigQueryCommand do
       input_file File.join(SAMPLE_DIR, "hive_result.txt")
     end
     cmd = cmd.build[0]
-    cmd = cmd.to_job.to_command(@config)
-
     cmd.execute
   end
 
-  it "sholud work with an empty file" do
+  it "should work with an empty file" do
     allow_any_instance_of(PatriotGCP::Ext::BigQuery).to receive(:bq_load)
     cmd = new_command(PatriotGCP::Command::LoadToBigQueryCommand) do  
       inifile path_to_test_config('test-bigquery.ini')
@@ -57,10 +53,164 @@ describe PatriotGCP::Command::LoadToBigQueryCommand do
     cmd = cmd.build[0]
     cmd = cmd.to_job.to_command(@config)
 
+    cmd.configure
     cmd.execute
   end 
 
-  it "sholud raise an error when the given file doesn't exist" do
+  it "should raise an error with ini(set:project_id) and pbc(set:none)" do
+    allow_any_instance_of(PatriotGCP::Ext::BigQuery).to receive(:bq_load)
+    cmd = new_command(PatriotGCP::Command::LoadToBigQueryCommand) do  
+      inifile path_to_test_config('test-bigquery-with-project_id.ini')
+      table 'test-table'
+      schema 'field1'
+      input_file File.join(SAMPLE_DIR, "hive_result.txt")
+    end 
+    cmd = cmd.build[0]
+    expect{cmd.execute}.to raise_error(
+      PatriotGCP::Command::LoadToBigQueryCommand::BigQueryException,
+      "configuration for BigQuery is not enough."
+    )
+  end 
+
+  it "should raise an error with ini(set:dataset) and pbc(set:none)" do
+    allow_any_instance_of(PatriotGCP::Ext::BigQuery).to receive(:bq_load)
+    cmd = new_command(PatriotGCP::Command::LoadToBigQueryCommand) do  
+      inifile path_to_test_config('test-bigquery-with-dataset.ini')
+      table 'test-table'
+      schema 'field1'
+      input_file File.join(SAMPLE_DIR, "hive_result.txt")
+    end 
+    cmd = cmd.build[0]
+    expect{cmd.execute}.to raise_error(
+      PatriotGCP::Command::LoadToBigQueryCommand::BigQueryException,
+      "configuration for BigQuery is not enough."
+    )
+  end 
+
+  it "should raise an error with ini(set:none) and pbc(set:project_id)" do
+    allow_any_instance_of(PatriotGCP::Ext::BigQuery).to receive(:bq_load)
+    cmd = new_command(PatriotGCP::Command::LoadToBigQueryCommand) do  
+      inifile path_to_test_config('test-bigquery-without-project_id-and-dataset.ini')
+      project_id 'test-project'
+      table 'test-table'
+      schema 'field1'
+      input_file File.join(SAMPLE_DIR, "hive_result.txt")
+    end 
+    cmd = cmd.build[0]
+    expect{cmd.execute}.to raise_error(
+      PatriotGCP::Command::LoadToBigQueryCommand::BigQueryException,
+      "configuration for BigQuery is not enough."
+    )
+  end 
+
+  it "should raise an error with ini(set:none) and pbc(set:dataset)" do
+    allow_any_instance_of(PatriotGCP::Ext::BigQuery).to receive(:bq_load)
+    cmd = new_command(PatriotGCP::Command::LoadToBigQueryCommand) do  
+      inifile path_to_test_config('test-bigquery-without-project_id-and-dataset.ini')
+      dataset 'test-dataset'
+      table 'test-table'
+      schema 'field1'
+      input_file File.join(SAMPLE_DIR, "hive_result.txt")
+    end 
+    cmd = cmd.build[0]
+    expect{cmd.execute}.to raise_error(
+      PatriotGCP::Command::LoadToBigQueryCommand::BigQueryException,
+      "configuration for BigQuery is not enough."
+    )
+  end 
+
+  it "should raise an error with ini(set:none) and pbc(set:none)" do
+    allow_any_instance_of(PatriotGCP::Ext::BigQuery).to receive(:bq_load)
+    cmd = new_command(PatriotGCP::Command::LoadToBigQueryCommand) do  
+      inifile path_to_test_config('test-bigquery-without-project_id-and-dataset.ini')
+      table 'test-table'
+      schema 'field1'
+      input_file File.join(SAMPLE_DIR, "hive_result.txt")
+    end 
+    cmd = cmd.build[0]
+    expect{cmd.execute}.to raise_error(
+      PatriotGCP::Command::LoadToBigQueryCommand::BigQueryException,
+      "configuration for BigQuery is not enough."
+    )
+  end 
+
+  it "should work with ini(set:none) and pbc(set:project_id, dataset)" do
+    allow_any_instance_of(PatriotGCP::Ext::BigQuery).to receive(:bq_load)
+    cmd = new_command(PatriotGCP::Command::LoadToBigQueryCommand) do  
+      inifile path_to_test_config('test-bigquery-without-project_id-and-dataset.ini')
+      project_id 'test-project-pbc'
+      dataset 'test-dataset-pbc'
+      table 'test-table'
+      schema 'field1'
+      input_file File.join(SAMPLE_DIR, "hive_result.txt")
+    end 
+    cmd = cmd.build[0]
+    cmd.execute
+    expect(cmd.instance_variable_get(:@project_id)).to eq('test-project-pbc')
+    expect(cmd.instance_variable_get(:@dataset)).to eq('test-dataset-pbc')
+  end 
+
+  it "should work with ini(set:project_id, dataset) and pbc(set:none)" do
+    allow_any_instance_of(PatriotGCP::Ext::BigQuery).to receive(:bq_load)
+    cmd = new_command(PatriotGCP::Command::LoadToBigQueryCommand) do  
+      inifile path_to_test_config('test-bigquery-with-project_id-and-dataset.ini')
+      table 'test-table'
+      schema 'field1'
+      input_file File.join(SAMPLE_DIR, "hive_result.txt")
+    end 
+    cmd = cmd.build[0]
+    cmd.execute
+    expect(cmd.instance_variable_get(:@project_id)).to eq('test-project')
+    expect(cmd.instance_variable_get(:@dataset)).to eq('test-dataset')
+  end 
+
+  it "should work with ini(set:project_id) and pbc(set:dataset)" do
+    allow_any_instance_of(PatriotGCP::Ext::BigQuery).to receive(:bq_load)
+    cmd = new_command(PatriotGCP::Command::LoadToBigQueryCommand) do  
+      inifile path_to_test_config('test-bigquery-with-project_id.ini')
+      dataset 'test-dataset-pbc'
+      table 'test-table'
+      schema 'field1'
+      input_file File.join(SAMPLE_DIR, "hive_result.txt")
+    end 
+    cmd = cmd.build[0]
+    cmd.execute
+    expect(cmd.instance_variable_get(:@project_id)).to eq('test-project')
+    expect(cmd.instance_variable_get(:@dataset)).to eq('test-dataset-pbc')
+  end 
+
+  it "should work with ini(set:dataset) and pbc(set:project_id)" do
+    allow_any_instance_of(PatriotGCP::Ext::BigQuery).to receive(:bq_load)
+    cmd = new_command(PatriotGCP::Command::LoadToBigQueryCommand) do  
+      inifile path_to_test_config('test-bigquery-with-dataset.ini')
+      project_id 'test-project-pbc'
+      table 'test-table'
+      schema 'field1'
+      input_file File.join(SAMPLE_DIR, "hive_result.txt")
+    end 
+    cmd = cmd.build[0]
+    cmd.execute
+    expect(cmd.instance_variable_get(:@project_id)).to eq('test-project-pbc')
+    expect(cmd.instance_variable_get(:@dataset)).to eq('test-dataset')
+  end 
+
+  it "should have priority in pbc settings with ini(set:project_id, dataset) and pbc(set:project_id, dataset)" do
+    allow_any_instance_of(PatriotGCP::Ext::BigQuery).to receive(:bq_load)
+    cmd = new_command(PatriotGCP::Command::LoadToBigQueryCommand) do  
+      inifile path_to_test_config('test-bigquery-with-project_id-and-dataset.ini')
+      project_id 'test-project-pbc'
+      dataset 'test-dataset-pbc'
+      table 'test-table'
+      schema 'field1'
+      input_file File.join(SAMPLE_DIR, "hive_result.txt")
+    end 
+    cmd = cmd.build[0]
+    cmd.execute
+    expect(cmd.instance_variable_get(:@project_id)).to eq('test-project-pbc')
+    expect(cmd.instance_variable_get(:@dataset)).to eq('test-dataset-pbc')
+  end 
+
+  it "should raise an error when the given file doesn't exist" do
     allow_any_instance_of(PatriotGCP::Ext::BigQuery).to receive(:bq_load)
     cmd = new_command(PatriotGCP::Command::LoadToBigQueryCommand) do  
       inifile path_to_test_config('test-bigquery.ini')
@@ -73,12 +223,10 @@ describe PatriotGCP::Command::LoadToBigQueryCommand do
               'allowLargeResults' => true
     end 
     cmd = cmd.build[0]
-    cmd = cmd.to_job.to_command(@config)
-
-    expect{cmd.execute}.to raise_error(Exception)
+    expect{cmd.execute}.to raise_error(Exception, "The given file doesn't exist.")
   end 
 
-  it "sholud raise an error when the ini file doesn't exist" do
+  it "should raise an error when the ini file doesn't exist" do
     allow_any_instance_of(PatriotGCP::Ext::BigQuery).to receive(:bq_load)
     cmd = new_command(PatriotGCP::Command::LoadToBigQueryCommand) do  
       inifile 'UNEXIST FILE'
@@ -90,9 +238,6 @@ describe PatriotGCP::Command::LoadToBigQueryCommand do
               'writeDisposition' => 'WRITE_APPEND',
               'allowLargeResults' => true
     end 
-    cmd = cmd.build[0]
-    cmd = cmd.to_job.to_command(@config)
-
-    expect{cmd.execute}.to raise_error(Exception)
+    expect{cmd.build[0]}.to raise_error(Exception, "inifile not found")
   end 
 end


### PR DESCRIPTION
you can set the following propeties at inifile or pbc.
project_id
dataset