### PR TITLE
Add REST API

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,6 +18,7 @@ Contents:
    pbc
    cli
    web
+   rest
    config
 
 Indices and tables

--- a/docs/source/rest.rst
+++ b/docs/source/rest.rst
@@ -1,0 +1,184 @@
+=====================
+REST API
+=====================
+Patriot Workflow Scheduler also provides REST API to manage jobs. The REST API works along with :doc:`'Web Console' <web>` at the moment.
+
+.. contents:: 
+   :local:
+   :depth: 2
+
+Authentication
+===================================
+Some APIs need Basic authentication. When calling these APIs, you should provide username and password which are written in the config file as `info_server.admin.username` and `info_server.admin.password` (See :doc:`'System Configuration' <config>`).
+
+APIs
+===================================
+Described here are the APIs provided at the moment.
+
+
+----
+
+
+GET /api/v1/jobs
+-----------------------------------
+Retrieves jobs with conditions provided with the parameters below.
+
+Parameters
+++++++++++++
+state (optional)
+  | Filters jobs (default: 4, FAILED). The options are:
+  |   -2: DISCARDED
+  |   -1: INIT
+  |   0: SUCCEEDED
+  |   1: WAIT
+  |   2: RUNNING
+  |   3: SUSPEND
+  |   4: FAILED
+limit (optional)
+  | Limits the number of jobs to get (default: 50).
+offset (optional)
+  | Adds offset (default: 0).
+filter_exp (optional)
+  | Filters jobs with the provided expression.
+  | This expression will be given to a LIKE clause of SQL.
+
+
+----
+
+
+GET /api/v1/jobs/stats
+-----------------------------------
+A handy way to get status and its number of jobs respectively.
+
+The responce would be like:
+
+::
+
+  [[-1, 3], [1, 100], [2, 10], [3, 0], [4, 20]]
+
+It means that there are 3 jobs with status -1(INIT), 100 jobs with status 1(WAIT), and so on. Note that status -2(DISCARDED) and 0(SUCCEEDED) are not included in this API.
+
+
+----
+
+
+GET /api/v1/jobs/<job_id>
+-----------------------------------
+Retrives the detail of the job.
+
+Parameters
+++++++++++++
+job_id (required*)
+  | Indicates the job_id
+include_dependency (optional)
+  | Determines if the information of `consumers` and `producers` is included (default: true)
+
+
+----
+
+
+GET /api/v1/jobs/<job_id>/histories
+-----------------------------------
+Retrives the execution history of the job.
+
+Parameters
+++++++++++++
+job_id (required*) 
+  | Indicates the job_id
+size (optional)
+  | Sets the size of history (default: 3)
+
+
+----
+
+
+POST /api/v1/jobs
+-----------------------------------
+Registers a new job.
+
+You should check what parameters the command requires and give them properly.
+
+Parameters
+++++++++++++
+COMMAND_CLASS (required*)
+  | Indicates a command class you want to create.
+name (optional, but strongly recommended)
+  | Indicates the job name. This parameter will be given to the command, and the command will generate a job_id accordingly.
+requisites (optional)
+  | Indicates products which will be required by the job before its execution.
+produces (optional)
+  | Indicates products which will be produced by the job after its execution.
+priority (optional)
+  | Sets the priority of the job (default: 1).
+exec_date (optional)
+  | Indicates the date when the job can start (default: the next day of the day when this API is called)
+  | The format is supposed to be "YYYY-MM-DD".
+start_after (optional)
+  | Indicates the time when the job can start after.
+  | The format is supposed to be "hh:mm:ss".
+exec_node (optional)
+  | Indicates a node (a group of hosts) where the job can be executed.
+exec_host (optional)
+  | Indicates a host where the job is executed.
+(other parameters, optional)
+  | If other parameters are given, they will be provided to the command which is created along with `COMMAND_CLASS`.
+
+Example of parameters
+++++++++++++
+
+Following parameters can be provided in the JSON body of a POST request.
+
+Here `name`, `name_suffix`, `connector`, `commands` are parameters for `Patriot.Command.ShCommand`.
+
+::
+
+  {
+   "COMMAND_CLASS": "Patriot.Command.ShCommand",
+   "name"         : "calculation_b"
+   "name_suffix"  : "2016-01-01"
+   "priority"     : 10,
+   "exec_date"    : "2016-01-01",
+   "start_after"  : "01:30:00",
+   "connector"    : "&&",
+   "commands"     : ["sudo -u hdfs hadoop fs -rmr /tmp/nbu_battleslot_slot/2013-07-06"]}],
+   "exec_node"    : "calc_node",
+   "requisites"   : ["calculation_a_2016-01-01", "master_data_2016-01-01],
+   "produces"     : ["calculation_b_2016_01_01"],
+  }
+
+This request will return a JSON response like:
+
+::
+
+  {
+   "job_id": "sh_calculation_b_2016-01-01",
+   "state" : "INIT"
+  }
+
+
+----
+
+
+PUT /api/v1/jobs/<job_id>
+-----------------------------------
+Modifies the state of the specified job.
+
+Parameters
+++++++++++++
+job_id (required*)
+  | Indicates the job_id
+state(required*)
+  | Indicates a new state.
+
+
+----
+
+
+DELETE /api/v1/jobs/<job_id>
+-----------------------------------
+Deletes the specified job and its relation.
+
+Parameters
+++++++++++++
+job_id (required*)
+  | Indicates the job_id

--- a/lib/patriot/job_store/base.rb
+++ b/lib/patriot/job_store/base.rb
@@ -147,7 +147,7 @@ module Patriot
         }.compact.flatten
         consumers = get_consumers(products)
         while !consumers.empty?
-          jobs = consumers.keys.map{|jid| get_job(jid)}.compact
+          jobs = consumers.map{|job| get_job(job["job_id"])}.compact
           yield self, jobs
           products = jobs.map{|j| j[Patriot::Command::PRODUCTS_ATTR]}.compact.flatten
           consumers = get_consumers(products)

--- a/lib/patriot/job_store/in_memory_store.rb
+++ b/lib/patriot/job_store/in_memory_store.rb
@@ -148,23 +148,31 @@ module Patriot
       def get_producers(products, opts = {:include_attrs => [Patriot::Command::STATE_ATTR]})
         opts = {:include_attrs => []}.merge(opts)
         products = [products] unless products.is_a?(Array)
-        producers = {}
-        products.each{|product| 
-          @producers.map{|pid, prods| 
-            producers[pid.to_s] = @jobs[pid].filter_attributes(opts[:include_attrs]) if prods.include?(product)
+        producers = []
+        products.each{|product|
+          @producers.map{|pid, prods|
+            if prods.include?(product)
+              job = @jobs[pid].filter_attributes(opts[:include_attrs])
+              job["job_id"] = pid.to_s
+              producers.push(job)
+            end
           }
         }
         return producers
       end
-  
+
       # @see Patriot::JobStore::Base#get_consumers
       def get_consumers(products, opts = {:include_attrs => [Patriot::Command::STATE_ATTR]})
         opts = {:include_attrs => []}.merge(opts)
         products = [products] unless products.is_a?(Array)
-        consumers = {}
+        consumers = []
         products.each{|product|
-          @consumers.map{|pid, prods| 
-            consumers[pid.to_s] = @jobs[pid].filter_attributes(opts[:include_attrs]) if prods.include?(product)
+          @consumers.map{|pid, prods|
+            if prods.include?(product)
+              job = @jobs[pid].filter_attributes(opts[:include_attrs])
+              job["job_id"] = pid.to_s
+              consumers.push(job)
+            end
           }
         }
         return consumers
@@ -208,7 +216,7 @@ module Patriot
       # @see Patriot::JobStore::Base#delete_job
       def delete_job(job_id)
         job_id = job_id.to_sym
-        @mutex.synchronize do 
+        @mutex.synchronize do
           @job_states.each{|s,js| js.delete(job_id)}
           @jobs.delete(job_id)
           @producers.delete(job_id)

--- a/lib/patriot/tool/patriot_commands/job.rb
+++ b/lib/patriot/tool/patriot_commands/job.rb
@@ -41,10 +41,12 @@ module Patriot
               job[Patriot::Command::REQUISITES_ATTR].each do |product|
                 products = job_store.get_producers(product)
                 values << "#{'  '*indent}<= #{product} = WARN: no producer exists" if products.empty?
-                products.each do |jid, attrs|
-                  dep_status = "#{jid}, #{attrs[Patriot::Command::STATE_ATTR]}"
+                products.each do |p|
+                  jid = p['job_id']
+                  state = p[Patriot::Command::STATE_ATTR]
+                  dep_status = "#{jid}, #{state}"
                   producer_job = job_store.get(jid, :include_dependency => true)
-                  unless producer_job['consumers'].keys.include?(job_id)
+                  unless producer_job['consumers'].map{|c| c['job_id']}.include?(job_id)
                     dep_status = "WARN: currupted dependency #{dep_status}"
                   end
                   values << "#{'  '*indent}<= #{product} = #{dep_status}"

--- a/lib/patriot/worker/info_server.rb
+++ b/lib/patriot/worker/info_server.rb
@@ -39,7 +39,7 @@ module Patriot
           @logger.info("port is not set. starting info server is skipped")
           return
         end
-        @server_thread = Thread.new do 
+        @server_thread = Thread.new do
           begin
             @handler = eval(@config.get(RACK_HANDLER_KEY, DEFAULT_RACK_HANDLER))
             app = Rack::URLMap.new(get_url_map)
@@ -58,6 +58,7 @@ module Patriot
         urls = @config.get(URLS_KEY, nil)
         if urls.nil?
           urlmap = {"/jobs"   => Patriot::Worker::Servlet::JobServlet,
+                    "/api/v1/jobs" => Patriot::Worker::Servlet::JobAPIServlet,
                     "/worker" => Patriot::Worker::Servlet::WorkerStatusServlet}
         else
           urlmap = {}

--- a/lib/patriot/worker/servlet.rb
+++ b/lib/patriot/worker/servlet.rb
@@ -16,6 +16,7 @@ module Patriot
       PASSWORD_KEY = 'info_server.admin.password'
 
       require 'patriot/worker/servlet/job_servlet.rb'
+      require 'patriot/worker/servlet/job_api_servlet.rb'
       require 'patriot/worker/servlet/worker_status_servlet.rb'
 
     end

--- a/lib/patriot/worker/servlet/job_api_servlet.rb
+++ b/lib/patriot/worker/servlet/job_api_servlet.rb
@@ -1,0 +1,158 @@
+require 'sinatra/base'
+require 'sinatra/contrib'
+
+module Patriot
+  module Worker
+    module Servlet
+      # excepton thrown in case job not found
+      class JobNotFoundException < Exception; end
+      # provide job management functionalities
+      class JobAPIServlet < Sinatra::Base
+        register Sinatra::Contrib
+        include Patriot::Util::DateUtil
+        include Patriot::Command::Parser
+
+        set :show_exceptions, :after_handler
+
+        # @param worker [Patriot::Wokrer::Base]
+        # @param config [Patriot::Util::Config::Base]
+        def self.configure(worker, config)
+          @@job_store = worker.job_store
+          @@config = config
+          @@username  = config.get(USERNAME_KEY, "")
+          @@password  = config.get(PASSWORD_KEY, "")
+        end
+
+        ### Helper Methods
+        helpers do
+          # require authorization for updating
+          def protected!
+            return if authorized?
+            headers['WWW-Authenticate'] = 'Basic Realm="Admin Only"'
+            halt 401, "Not Authorized"
+          end
+
+          # authorize user (basic authentication)
+          def authorized?
+            @auth ||= Rack::Auth::Basic::Request.new(request.env)
+            return @auth.provided? && @auth.basic? && @auth.credentials && @auth.credentials == [@@username, @@password]
+          end
+        end
+
+
+        get '/stats' do
+          return JSON.generate(@@job_store.get_job_size(:ignore_states => [Patriot::JobStore::JobState::SUCCEEDED]))
+        end
+
+
+        get '/' do
+          state  = (params['state']  || Patriot::JobStore::JobState::FAILED).to_i
+          limit  = (params['limit']  || DEFAULT_JOB_LIMIT).to_i
+          offset = (params['offset'] || DEFAULT_JOB_OFFSET).to_i
+
+          query = {:limit  => limit, :offset => offset}
+          query[:filter_exp] = params['filter_exp'] unless params['filter_exp'].blank?
+          job_ids = @@job_store.find_jobs_by_state(state, query) || []
+          return JSON.generate(job_ids.map{|job_id| {:job_id => job_id, :state => state}})
+        end
+
+
+        get '/:job_id' do
+          job_id = params[:job_id]
+          job = @@job_store.get(job_id, {:include_dependency => true})
+          halt(404, json({ERROR: "Job #{job_id} not found"})) if job.nil?
+          return JSON.generate(job.attributes.merge({'job_id' => job_id, "update_id" => job.update_id}))
+        end
+
+
+        get '/:job_id/histories' do
+          job_id = params[:job_id]
+          history_size = params['size'] || 3
+          histories = @@job_store.get_execution_history(job_id, {:limit => history_size})
+          return JSON.generate(histories)
+        end
+
+
+        post '/' do
+          protected!
+          body = JSON.parse(request.body.read)
+          halt(400, json({ERROR: "COMMAND_CLASS is not provided"})) if body["COMMAND_CLASS"].blank?
+          halt(400, json({ERROR: "Patriot::Command::CommandGroup is not acceptable"})) if body["COMMAND_CLASS"] == "Patriot::Command::CommandGroup"
+          command_class = body.delete("COMMAND_CLASS").gsub(/\./, '::').constantize
+
+          # build_commands returns several jobs only when the class is CommandGroup
+          job = build_commands(command_class, body)[0]
+
+          @@job_store.register(Time.now.to_i, [job])
+          return JSON.generate({:job_id => job.job_id})
+        end
+
+
+        put '/:job_id' do
+          protected!
+          job_id = params['job_id']
+          job = @@job_store.get(job_id)
+          halt(404, json({ERROR: "Job #{job_id} not found"})) if job.nil?
+
+          body = JSON.parse(request.body.read)
+          state = body['state']
+          set_state_of_jobs([job_id], state)
+          return JSON.generate({"job_id" => job_id, "state" => state})
+        end
+
+
+        delete '/:job_id' do
+          protected!
+          job_id = params['job_id']
+          job = @@job_store.get(job_id)
+          halt(404, json({ERROR: "Job #{job_id} not found"})) if job.nil?
+
+          @@job_store.delete_job(job_id)
+          return JSON.generate({"job_id" => job_id})
+        end
+
+
+        error JobNotFoundException do
+          "Job #{env['sinatra.error'].message} is not found"
+        end
+
+        # @private
+        def set_state_of_jobs(job_ids, state, opts = {})
+          opts = {:include_subsequent => false}.merge(opts)
+          update_id = Time.now.to_i
+          @@job_store.set_state(update_id, job_ids, state)
+          if opts[:include_subsequent]
+            @@job_store.process_subsequent(job_ids) do |job_store, jobs|
+              @@job_store.set_state(update_id, jobs.map(&:job_id), state)
+            end
+          end
+        end
+        private :set_state_of_jobs
+
+        # @private
+        def construct_time(exec_date, start_after)
+          return nil if exec_date.blank? && start_after.blank?
+          # set tomorrow as default
+          date = (exec_date || (Date.today + 1).strftime("%Y-%m-%d")).split("-").map(&:to_i)
+          # set midnight as default
+          time = (start_after || "00:00:00").split(":").map(&:to_i)
+          return Time.new(date[0], date[1], date[2], time[0], time[1], time[2])
+        end
+        private :construct_time
+
+        # @private
+        def build_commands(clazz, params)
+          _params = params.dup
+          _params["target_datetime"] = Date.today
+          cmd = clazz.new(@@config)
+          cmd.produce(_params.delete("products")) unless _params["products"].nil?
+          cmd.require(_params.delete("requisites")) unless _params["requisites"].nil?
+          cmds = cmd.build(_params)
+          return cmds.map{|c| c.to_job}
+        end
+        private :build_commands
+
+      end
+    end
+  end
+end

--- a/lib/patriot/worker/servlet/job_servlet.rb
+++ b/lib/patriot/worker/servlet/job_servlet.rb
@@ -47,9 +47,11 @@ module Patriot
           query = {:limit  => params['limit']  || DEFAULT_JOB_LIMIT,
                    :offset => params['offset'] || DEFAULT_JOB_OFFSET}
           query[:filter_exp] = params['filter_exp'] if params.has_key?('filter_exp') && params['filter_exp'] != ""
-          jobs = @@job_store.find_jobs_by_state(state.to_i, query)
-          jobs ||= []
-          respond_with :jobs, {:jobs => jobs, :state => state, :filter_exp => query[:filter_exp]}.merge(query)
+          job_ids = @@job_store.find_jobs_by_state(state.to_i, query)
+          job_ids ||= []
+          respond_with :jobs, {:jobs => job_ids.map{|job_id| {:job_id => job_id, :state => state}},
+                               :state => state,
+                               :filter_exp => query[:filter_exp]}.merge(query)
         end
 
         post '/' do
@@ -72,7 +74,7 @@ module Patriot
           raise JobNotFoundException, job_id if job.nil?
           update_job_size(job[Patriot::Command::STATE_ATTR])
           histories = @@job_store.get_execution_history(job_id, {:limit => history_size})
-          # respond_with :job, {:job => job, :histories => histories} 
+          # respond_with :job, {:job => job, :histories => histories}
           respond_to do |f|
             f.on('text/html'){ erb :job, :locals => {:job => job, :histories => histories} }
             # for monitoring

--- a/plugins/patriot-gcp/spec/patriot_gcp/ext/bigquery_spec.rb
+++ b/plugins/patriot-gcp/spec/patriot_gcp/ext/bigquery_spec.rb
@@ -12,7 +12,7 @@ describe PatriotGCP::Ext::BigQuery do
   end
 
 
-  it "sholud load data to bigquery" do
+  it "should load data to bigquery" do
     api_client_mock = double('api-client-mock')
     allow(api_client_mock).to receive(:discovered_api).with('bigquery', 'v2'){
         double(nil,

--- a/plugins/patriot-hadoop/spec/patriot_hadoop/command/hive2bigquery_spec.rb
+++ b/plugins/patriot-hadoop/spec/patriot_hadoop/command/hive2bigquery_spec.rb
@@ -8,7 +8,7 @@ describe PatriotHadoop::Command::HiveCommand do
     @config = config_for_test
   end
 
-  it "sholud execute hive query" do
+  it "should execute hive query" do
     query = 'select count(1) from tmp where dt = \'2011-12-12\' and dev = \'test\''
     cmd = new_command(PatriotHadoop::Command::HiveCommand) do
       hive_ql query
@@ -30,7 +30,7 @@ describe PatriotHadoop::Command::HiveCommand do
     cmd.execute
   end
 
-  it "sholud execute hive query without output_prefix" do
+  it "should execute hive query without output_prefix" do
     query = 'select count(1) from tmp where dt = \'2011-12-12\' and dev = \'test\''
     cmd = new_command(PatriotHadoop::Command::HiveCommand) do
       hive_ql query
@@ -52,7 +52,7 @@ describe PatriotHadoop::Command::HiveCommand do
     cmd.execute
   end
 
-  it "sholud execute hive query with exec_user" do
+  it "should execute hive query with exec_user" do
     query = 'select count(1) from tmp where dt = \'2011-12-12\' and dev = \'test\''
     exec_user = 'user1'
     cmd = new_command(PatriotHadoop::Command::HiveCommand) do
@@ -76,7 +76,7 @@ describe PatriotHadoop::Command::HiveCommand do
     cmd.execute
   end
 
-  it "sholud execute hive query with properties" do
+  it "should execute hive query with properties" do
     query = 'select count(1) from tmp where dt = \'2011-12-12\' and dev = \'test\''
     cmd = new_command(PatriotHadoop::Command::HiveCommand) do
       hive_ql query
@@ -101,7 +101,7 @@ describe PatriotHadoop::Command::HiveCommand do
     cmd.execute
   end
 
-  it "sholud execute hive query and the result is empty" do
+  it "should execute hive query and the result is empty" do
     query = 'select count(1) from tmp where dt = \'2011-12-12\' and dev = \'test\''
     cmd = new_command(PatriotHadoop::Command::HiveCommand) do
       hive_ql query

--- a/skel/public/templates/_jobs.erb
+++ b/skel/public/templates/_jobs.erb
@@ -1,4 +1,3 @@
-<% job_state = Hash.new(Patriot::JobStore::JobState.name_of(state)) if job_state.nil? && !state.nil? %>
 <% prefix = "" if prefix.nil? %>
 <form id="state_update_form" method="POST" action="/jobs/">
   <input type="hidden" name="_method" value="put">
@@ -7,11 +6,11 @@
       <th><input type="checkbox" id="selectAllJob" onclick="$('input:checkbox[name=\'job_ids[]\']').prop('checked', $(this).prop('checked'));"></input></th>
       <th>job_id</th>
       <th>State</th>
-      <% jobs.each do |job_id| %>
+      <% jobs.each do |job| %>
         </tr><tr>
-        <td><input type="checkbox" data-job-id="<%= job_id %>" data-job-state="<%= job_state[job_id] %>" name="job_ids[]" value="<%= job_id %>"></td>
-          <td><%= to_job_link(job_id) %></td>
-          <td> <%= job_state[job_id] %></td>
+        <td><input type="checkbox" data-job-id="<%= job[:job_id] %>" data-job-state="<%= Patriot::JobStore::JobState.name_of(job[:state].to_i) %>" name="job_ids[]" value="<%= job[:job_id] %>"></td>
+          <td><%= to_job_link(job[:job_id]) %></td>
+          <td><%= Patriot::JobStore::JobState.name_of(job[:state].to_i) %></td>
       <% end %>
     </tr>
   </table>

--- a/skel/public/templates/job.erb
+++ b/skel/public/templates/job.erb
@@ -108,12 +108,10 @@
 <h3> Dependency Info. </h3>
 <% if !producers.nil? && !producers.empty? %>
 <h5> Before </h5>
-<% p_job_state = {}; producers.each{|jid, attr| p_job_state[jid] = Patriot::JobStore::JobState.name_of(attr[:state].to_i)} %>
-<%= erb :_jobs, :locals => {:jobs => producers.keys, :job_state => p_job_state, :prefix => "p_"}, :layout => false %>
+<%= erb :_jobs, :locals => {:jobs => producers, :prefix => "p_"}, :layout => false %>
 <% end %>
 <% if !consumers.nil? && !consumers.empty? %>
 <h5> After </h5>
-<% c_job_state = {}; consumers.each{|jid, attr| c_job_state[jid] = Patriot::JobStore::JobState.name_of(attr[:state].to_i)} %>
-<%= erb :_jobs, :locals => {:jobs => consumers.keys, :job_state => c_job_state, :prefix => "c_"}, :layout => false %>
+<%= erb :_jobs, :locals => {:jobs => consumers, :prefix => "c_"}, :layout => false %>
 <% end %>
 

--- a/spec/config/test.ini
+++ b/spec/config/test.ini
@@ -19,4 +19,6 @@ node.own.type=own
 node.own.threads=2
 node.any.type=any
 node.any.threads=3
+info_server.admin.username=admin
+info_server.admin.password=password
  

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -1,4 +1,4 @@
 require 'helper/test_environment'
 require 'helper/jobstore_matcher'
 
-include TestEnvirionment
+include TestEnvironment

--- a/spec/helper/test_environment.rb
+++ b/spec/helper/test_environment.rb
@@ -1,4 +1,4 @@
-module  TestEnvirionment
+module  TestEnvironment
   include Patriot::Util::Config
 
   TEST_TARGET_DATE = Time.new(2015, 4, 1)

--- a/spec/patriot/command/base_spec.rb
+++ b/spec/patriot/command/base_spec.rb
@@ -13,7 +13,7 @@ describe Patriot::Command::Base do
     @target_datetime = Time.new(YEAR, MONTH, DAY)
   end
 
-  it "sholud extract start after" do
+  it "should extract start after" do
     cmd = new_command(Patriot::Command::ShCommand) do
       produce ["product1_#{@hour}"]  
       require ["product2_#{@hour}"]  
@@ -28,7 +28,7 @@ describe Patriot::Command::Base do
     expect(cmds[0].start_date_time).to eq Time.new(YEAR,MONTH,DAY,0,0,0)
   end
 
-  it "sholud not have reserved word" do
+  it "should not have reserved word" do
     cmd = new_command(Patriot::Command::ShCommand) do
       produce ["product1_#{@hour}"]  
       require ["product2_#{@hour}"]  
@@ -39,7 +39,7 @@ describe Patriot::Command::Base do
     expect{cmd.build}.to raise_error
   end
 
-  it "sholud handle double quote" do
+  it "should handle double quote" do
     cmd = new_command(Patriot::Command::ShCommand) do
       name 'test_"import'
       commands "echo \"#{YEAR}\""
@@ -50,7 +50,7 @@ describe Patriot::Command::Base do
     expect(cmd.instance_variable_get(:@commands)[0]).to eq "echo \"#{YEAR}\""
   end
 
-  it "sholud be suspended" do
+  it "should be suspended" do
     cmd = new_command(Patriot::Command::ShCommand) do
       suspend
       name 'test_"import'
@@ -60,7 +60,7 @@ describe Patriot::Command::Base do
     expect(cmd.instance_variable_get(:@state)).to eq Patriot::JobStore::JobState::SUSPEND
   end
 
-  it "sholud be skipped" do
+  it "should be skipped" do
     cmd = new_command(Patriot::Command::ShCommand) do
       skip
       name 'test_"import'

--- a/spec/patriot/command/composite_nest_spec.rb
+++ b/spec/patriot/command/composite_nest_spec.rb
@@ -32,7 +32,7 @@ describe Patriot::Command::CompositeCommand do
     FileUtils.rm_r(tmp_file) if File.exist?(tmp_file) 
   end
 
-  it "sholud execute a multiple command sequentially" do
+  it "should execute a multiple command sequentially" do
     @valid_cmd1.execute
     File.open(tmp_file) do |f|
       output = f.readlines
@@ -40,7 +40,7 @@ describe Patriot::Command::CompositeCommand do
     end
   end
 
-  it "sholud handle dependency of contained commands" do
+  it "should handle dependency of contained commands" do
     expect(@valid_cmd1['requisites']).to contain_exactly('a')
     expect(@valid_cmd1['products']).to contain_exactly('b')
   end

--- a/spec/patriot/command/composite_spec.rb
+++ b/spec/patriot/command/composite_spec.rb
@@ -28,7 +28,7 @@ describe Patriot::Command::ShCommand do
     FileUtils.rm_r(tmp_file) if File.exist?(tmp_file) 
   end
 
-  it "sholud execute a multiple command sequentially" do
+  it "should execute a multiple command sequentially" do
     @valid_cmd1.execute
     File.open(tmp_file) do |f|
       output = f.readlines
@@ -36,7 +36,7 @@ describe Patriot::Command::ShCommand do
     end
   end
 
-  it "sholud handle dependency of contained jobs" do
+  it "should handle dependency of contained jobs" do
     expect(@valid_cmd1['requisites']).to contain_exactly('a')
     expect(@valid_cmd1['products']).to contain_exactly('b')
   end

--- a/spec/patriot/command/parser_spec.rb
+++ b/spec/patriot/command/parser_spec.rb
@@ -3,7 +3,7 @@ require 'init_test'
 describe Patriot::Command::Parser do 
   include Patriot::Command::Parser
 
-  it "sholud not parse each file separately" do
+  it "should not parse each file separately" do
     parser = Patriot::Tool::BatchParser.new(config_for_test)
     commands = parser.parse('2015-04-01', [1,2].map{|i| File.join(ROOT_PATH, "spec","pbc","exec_node#{i}.pbc") })
     expect(commands[0].instance_variable_get(:@exec_node)).not_to eq commands[1].instance_variable_get(:@exec_node)

--- a/spec/patriot/command/post_processor/mail_spec.rb
+++ b/spec/patriot/command/post_processor/mail_spec.rb
@@ -49,7 +49,7 @@ EOJ
     @job_store.register(@update_id, @jobs)
   end
 
-  it "sholud notify on success with both setting" do
+  it "should notify on success with both setting" do
     job_ticket = Patriot::JobStore::JobTicket.new("sh_both_success_#{@dt}", @update_id)
     expect_any_instance_of(Patriot::Command::PostProcessor::MailNotification).to receive(:deliver).with("from@test", "to@test", "#{job_ticket.job_id} has been successfully finished", anything)
     expect(@worker.execute_job(job_ticket)).to eq Patriot::Command::ExitCode::SUCCEEDED
@@ -57,7 +57,7 @@ EOJ
     expect(job).to be_succeeded_in @job_store
   end
 
-  it "sholud notify on failure with both setting" do
+  it "should notify on failure with both setting" do
     job_ticket = Patriot::JobStore::JobTicket.new("sh_both_fail_#{@dt}", @update_id)
     expect_any_instance_of(Patriot::Command::PostProcessor::MailNotification).to receive(:deliver).with("from@test", "to@test", "#{job_ticket.job_id} has been failed", anything)
     expect(@worker.execute_job(job_ticket)).to eq Patriot::Command::ExitCode::FAILED
@@ -65,7 +65,7 @@ EOJ
     expect(job).to be_failed_in @job_store
   end
 
-  it "sholud notify on success with success enabled setting" do
+  it "should notify on success with success enabled setting" do
     job_ticket = Patriot::JobStore::JobTicket.new("sh_success_success_#{@dt}", @update_id)
     expect_any_instance_of(Patriot::Command::PostProcessor::MailNotification).to receive(:deliver).with("from@test", "to@test", "#{job_ticket.job_id} has been successfully finished", anything)
     expect(@worker.execute_job(job_ticket)).to eq Patriot::Command::ExitCode::SUCCEEDED
@@ -73,7 +73,7 @@ EOJ
     expect(job).to be_succeeded_in @job_store
   end
 
-  it "sholud not notify on failure with success enabled setting" do
+  it "should not notify on failure with success enabled setting" do
     job_ticket = Patriot::JobStore::JobTicket.new("sh_success_fail_#{@dt}", @update_id)
     expect_any_instance_of(Patriot::Command::PostProcessor::MailNotification).not_to receive(:deliver)
     expect(@worker.execute_job(job_ticket)).to eq Patriot::Command::ExitCode::FAILED
@@ -81,7 +81,7 @@ EOJ
     expect(job).to be_failed_in @job_store
   end
 
-  it "sholud not notify on success with failure enabled setting" do
+  it "should not notify on success with failure enabled setting" do
     job_ticket = Patriot::JobStore::JobTicket.new("sh_fail_success_#{@dt}", @update_id)
     expect_any_instance_of(Patriot::Command::PostProcessor::MailNotification).not_to receive(:deliver)
     expect(@worker.execute_job(job_ticket)).to eq Patriot::Command::ExitCode::SUCCEEDED
@@ -89,7 +89,7 @@ EOJ
     expect(job).to be_succeeded_in @job_store
   end
 
-  it "sholud notify on failure with failure enabled setting" do
+  it "should notify on failure with failure enabled setting" do
     job_ticket = Patriot::JobStore::JobTicket.new("sh_fail_fail_#{@dt}", @update_id)
     expect_any_instance_of(Patriot::Command::PostProcessor::MailNotification).to receive(:deliver).with("from@test", "to@test", "#{job_ticket.job_id} has been failed", anything)
     expect(@worker.execute_job(job_ticket)).to eq Patriot::Command::ExitCode::FAILED

--- a/spec/patriot/command/post_processor/retrial_spec.rb
+++ b/spec/patriot/command/post_processor/retrial_spec.rb
@@ -37,7 +37,7 @@ EOJ
     @job_store.register(@update_id, @jobs)
   end
 
-  it "sholud retry failed job" do
+  it "should retry failed job" do
     retry_job_id = 'sh_test_2015-08-01'
     0.upto(2) do |i|
       job_ticket = @job_store.get_job_tickets("", [])[0]

--- a/spec/patriot/command/post_processor/skip_on_fail_spec.rb
+++ b/spec/patriot/command/post_processor/skip_on_fail_spec.rb
@@ -6,7 +6,7 @@ describe Patriot::Command::PostProcessor::SkipOnFail do
 
   before :each do 
     @worker = Patriot::Worker::Base.new(config_for_test)
-    @job    = TestEnvirionment.build_job({
+    @job    = TestEnvironment.build_job({
         :post_processors => [Patriot::Command::PostProcessor::SkipOnFail.new],
         :commands        => 'no_such_a_command'
       })
@@ -15,7 +15,7 @@ describe Patriot::Command::PostProcessor::SkipOnFail do
     @job_store.register(@update_id, [@job])
   end
 
-  it "sholud execute a job" do
+  it "should execute a job" do
     job_entry = Patriot::JobStore::JobTicket.new(@job.job_id, @update_id)
     expect(@worker.execute_job(job_entry)).to eq Patriot::Command::ExitCode::FAILED
     expect(@job).to be_succeeded_in @job_store

--- a/spec/patriot/command/shcommand_spec.rb
+++ b/spec/patriot/command/shcommand_spec.rb
@@ -30,7 +30,7 @@ describe Patriot::Command::ShCommand do
     FileUtils.rm_r(tmp_file) if File.exist?(tmp_file) 
   end
 
-  it "sholud execute a command" do
+  it "should execute a command" do
     parser = Patriot::Tool::BatchParser.new(config_for_test)
     @valid_cmd1.execute
     File.open(tmp_file) do |f|
@@ -39,21 +39,21 @@ describe Patriot::Command::ShCommand do
     end   
   end
 
-  it "sholud raise an error" do
+  it "should raise an error" do
     parser = Patriot::Tool::BatchParser.new(config_for_test)
     expect{
       @invalid_cmd1.execute
     }.to raise_error(Patriot::Util::System::ExternalCommandException)
   end
 
-  it "sholud have a name" do
+  it "should have a name" do
     noname = new_command(Patriot::Command::ShCommand) do 
       commands 'echo /tmp/no_name' 
     end
     expect{noname.build}.to raise_error
   end
 
-  it "sholud has default connector name" do
+  it "should has default connector name" do
     cmd = new_command(Patriot::Command::ShCommand) do 
       name 'default_connector'
       commands 'echo /tmp/no_name' 

--- a/spec/patriot/job_store/rdb_job_store_spec.rb
+++ b/spec/patriot/job_store/rdb_job_store_spec.rb
@@ -19,8 +19,8 @@ unless ENV['TEST_DBMS'].nil?
     end
 
     it "should use strict datetime format" do
-      target_datetime = TestEnvirionment::TEST_TARGET_DATE.strftime("%Y-%m-%d")
-      job  = TestEnvirionment.build_job({:job_id => 'startafter_test'})
+      target_datetime = TestEnvironment::TEST_TARGET_DATE.strftime("%Y-%m-%d")
+      job  = TestEnvironment.build_job({:job_id => 'startafter_test'})
       job[Patriot::Command::START_DATETIME_ATTR] = Time.new(2010,1,31)
       expect_any_instance_of(Patriot::Util::DBClient::MySQL2Client).to receive(:do_insert).once.with(
         "INSERT INTO jobs (job_id,update_id,priority,state,start_after,node,host,content) VALUES ('sh_job_startafter_test_#{target_datetime}',#{@update_id},1,1,'2010-01-31 00:00:00',NULL,NULL,'{\\\"COMMAND_CLASS\\\":\\\"Patriot.Command.ShCommand\\\",\\\"connector\\\":\\\"&&\\\",\\\"commands\\\":[\\\"echo 1\\\"],\\\"name\\\":\\\"job_startafter_test\\\",\\\"name_suffix\\\":\\\"#{target_datetime}\\\"}')"

--- a/spec/patriot/tool/patriot_commands/job_spec.rb
+++ b/spec/patriot/tool/patriot_commands/job_spec.rb
@@ -26,10 +26,10 @@ describe Patriot::Tool::PatriotCommands::Job do
   describe "show valid dependency" do
     before :each do
       @update_id = Time.now.to_i
-      @p_job = TestEnvirionment.build_job({:produce => ['p1']})
-      @m_job = TestEnvirionment.build_job({:require => ['p1'], :produce => ['p2']})
-      @c_job = TestEnvirionment.build_job({:require => ['p2']})
-      @illegal_job = TestEnvirionment.build_job({:require => ['illegal']})
+      @p_job = TestEnvironment.build_job({:produce => ['p1']})
+      @m_job = TestEnvironment.build_job({:require => ['p1'], :produce => ['p2']})
+      @c_job = TestEnvironment.build_job({:require => ['p2']})
+      @illegal_job = TestEnvironment.build_job({:require => ['illegal']})
       @job_store.register(@update_id, [@p_job, @m_job, @c_job, @illegal_job])
     end
 
@@ -56,10 +56,10 @@ EOS
   describe "show incorrect dependency" do
     before :each do
       @update_id = Time.now.to_i
-      @p_job = TestEnvirionment.build_job({:produce => ['p1']})
-      @m_job = TestEnvirionment.build_job({:require => ['p1'], :produce => ['p2']})
-      @c_job = TestEnvirionment.build_job({:require => ['p2']})
-      @illegal_job = TestEnvirionment.build_job({:require => ['illegal']})
+      @p_job = TestEnvironment.build_job({:produce => ['p1']})
+      @m_job = TestEnvironment.build_job({:require => ['p1'], :produce => ['p2']})
+      @c_job = TestEnvironment.build_job({:require => ['p2']})
+      @illegal_job = TestEnvironment.build_job({:require => ['illegal']})
       @job_store.register(@update_id, [@p_job, @m_job, @c_job, @illegal_job])
       allow(@job_store).to receive(:get).and_call_original
       allow(@job_store).to receive(:get).with(anything, {:include_dependency => true}).and_return({'consumers' => {}, 'producers' => {}})

--- a/spec/patriot/util/config/inifile_config_spec.rb
+++ b/spec/patriot/util/config/inifile_config_spec.rb
@@ -6,7 +6,7 @@ describe Patriot::Util::Config::IniFileConfig do
   end
 
   describe "worker config" do
-    it "sholud return variables" do
+    it "should return variables" do
       expect(@config.get('info_server_port')).to eq '36104'
       expect(@config.get('none')).to be nil
     end

--- a/spec/patriot/util/date_util_spec.rb
+++ b/spec/patriot/util/date_util_spec.rb
@@ -19,7 +19,7 @@ describe Patriot::Util::DateUtil do
       val = date_format "2012-11-30", "23:12:34" , "%Y-%m-%d %H:%M:%S", {:day =>1}
       expect(val).to eq "2012-12-01 23:12:34"
     end
-    it "sholud add hour by date_format" do
+    it "should add hour by date_format" do
       val = date_format "2012-02-01", "23:12:34" , "%Y-%m-%d %H:%M:%S", {:hour =>1}
       expect(val).to eq "2012-02-02 00:12:34"
       val = date_format "2012-02-28", "23:12:34" , "%Y-%m-%d %H:%M:%S", {:hour =>1}
@@ -34,7 +34,7 @@ describe Patriot::Util::DateUtil do
       expect(val).to eq "2012-12-01 00:12:34"
     end
 
-    it "sholud subtract hour by date_format" do
+    it "should subtract hour by date_format" do
       val = date_format "2012-03-01", "00:12:34" , "%Y-%m-%d %H:%M:%S", {:hour =>-1}
       expect(val).to eq "2012-02-29 23:12:34"
       val = date_format "2013-03-01", "00:12:34" , "%Y-%m-%d %H:%M:%S", {:hour =>-1}
@@ -43,7 +43,7 @@ describe Patriot::Util::DateUtil do
       expect(val).to eq "2011-12-31 23:12:34"
     end
 
-    it "sholud add month and hourby date_format" do
+    it "should add month and hourby date_format" do
       val = date_format "2012-02-28", "23:12:34" , "%Y-%m-%d %H:%M:%S", {:month =>1, :hour =>1}
       expect(val).to eq "2012-03-29 00:12:34"
     end

--- a/spec/patriot/util/param_spec.rb
+++ b/spec/patriot/util/param_spec.rb
@@ -6,7 +6,7 @@ describe Patriot::Util::Param do
   end
 
   describe ".eval_string_attr" do
-    it "sholud eval string with vertical bar" do
+    it "should eval string with vertical bar" do
       expect(@obj.eval_string_attr '#{"abc|def"}').to eq "abc|def"
     end
 

--- a/spec/patriot/worker/base_spec.rb
+++ b/spec/patriot/worker/base_spec.rb
@@ -6,7 +6,7 @@ require 'patriot/worker/base'
 describe Patriot::Worker::Base do
   before :each do
     @worker_base = Patriot::Worker::Base.new(config_for_test)
-    @job1 = TestEnvirionment.build_job
+    @job1 = TestEnvironment.build_job
     @update_id = Time.now.to_i
     @job_store = @worker_base.instance_variable_get(:@job_store)
     @job_store.register(@update_id, [@job1])

--- a/spec/patriot/worker/info_server_spec.rb
+++ b/spec/patriot/worker/info_server_spec.rb
@@ -10,8 +10,8 @@ describe  Patriot::Worker::InfoServer do
                          Patriot::Worker::InfoServer::DEFAULT_PORT)
       @url = "http://127.0.0.1:#{port}"
       @worker = Patriot::Worker::MultiNodeWorker.new(@config)
-      @job1 = TestEnvirionment.build_job()
-      @job2 = TestEnvirionment.build_job()
+      @job1 = TestEnvironment.build_job()
+      @job2 = TestEnvironment.build_job()
       @job_store = @worker.instance_variable_get(:@job_store)
       @update_id = Time.now.to_i
       @job_store.register(@update_id, [@job1,@job2])
@@ -63,8 +63,8 @@ describe  Patriot::Worker::InfoServer do
       port = @config.get(Patriot::Worker::InfoServer::PORT_KEY)
       @url = "http://127.0.0.1:#{port}"
       @worker = Patriot::Worker::MultiNodeWorker.new(@config)
-      @job1 = TestEnvirionment.build_job()
-      @job2 = TestEnvirionment.build_job()
+      @job1 = TestEnvironment.build_job()
+      @job2 = TestEnvironment.build_job()
       @job_store = @worker.instance_variable_get(:@job_store)
       @update_id = Time.now.to_i
       @job_store.register(@update_id, [@job1,@job2])

--- a/spec/patriot/worker/multinode_worker_spec.rb
+++ b/spec/patriot/worker/multinode_worker_spec.rb
@@ -9,8 +9,8 @@ describe  Patriot::Worker::MultiNodeWorker do
   describe "init_worker" do
     before :each do
       @worker = Patriot::Worker::MultiNodeWorker.new(@config)
-      @job1 = TestEnvirionment.build_job()
-      @job2 = TestEnvirionment.build_job()
+      @job1 = TestEnvironment.build_job()
+      @job2 = TestEnvironment.build_job()
       @update_id = Time.now.to_i
       @job_store = @worker.instance_variable_get(:@job_store)
       @job_store.register(@update_id, [@job1,@job2])
@@ -53,8 +53,8 @@ describe  Patriot::Worker::MultiNodeWorker do
         @worker = Patriot::Worker::MultiNodeWorker.new(@config)
         @worker.init_worker
         @cycle = @worker.instance_variable_get(:@cycle)
-        @job1 = TestEnvirionment.build_job()
-        @job2 = TestEnvirionment.build_job()
+        @job1 = TestEnvironment.build_job()
+        @job2 = TestEnvironment.build_job()
         @job_store = @worker.instance_variable_get(:@job_store)
         @job_store.register(@update_id, [@job1,@job2])
       end
@@ -90,8 +90,8 @@ describe  Patriot::Worker::MultiNodeWorker do
       @worker = Patriot::Worker::MultiNodeWorker.new(@config)
       @worker.init_worker
       @cycle = @worker.instance_variable_get(:@cycle)
-      @job1 = TestEnvirionment.build_job()
-      @job2 = TestEnvirionment.build_job()
+      @job1 = TestEnvironment.build_job()
+      @job2 = TestEnvironment.build_job()
       @job_store = @worker.instance_variable_get(:@job_store)
       @job_store.register(@update_id, [@job1,@job2])
     end
@@ -138,8 +138,8 @@ describe  Patriot::Worker::MultiNodeWorker do
     end
 
     it "should be success" do
-      job1 = TestEnvirionment.build_job()
-      job2 = TestEnvirionment.build_job()
+      job1 = TestEnvironment.build_job()
+      job2 = TestEnvironment.build_job()
       job_ticket1 = Patriot::JobStore::JobTicket.new(job1.job_id, job1.update_id)
       job_ticket2 = Patriot::JobStore::JobTicket.new(job2.job_id, job2.update_id,'own')
       queue = Queue.new
@@ -163,7 +163,7 @@ describe  Patriot::Worker::MultiNodeWorker do
           puts "incomplete"
         end
       end.new(@config)
-      job1 = TestEnvirionment.build_job()
+      job1 = TestEnvironment.build_job()
       job_ticket1 = Patriot::JobStore::JobTicket.new(job1.job_id, job1.update_id)
       queue = Queue.new
       worker = Patriot::Worker::MultiNodeWorker.new(@config)

--- a/spec/patriot/worker/servlet/job_api_servlet_spec.rb
+++ b/spec/patriot/worker/servlet/job_api_servlet_spec.rb
@@ -1,0 +1,225 @@
+require 'json'
+require 'init_test'
+require 'rest_client'
+require 'patriot/worker/servlet/job_api_servlet'
+
+describe Patriot::Worker::Servlet::JobAPIServlet do
+
+  context "default config" do
+    before :all do
+      @config = config_for_test('worker')
+      port = @config.get(Patriot::Worker::InfoServer::PORT_KEY,
+                         Patriot::Worker::InfoServer::DEFAULT_PORT)
+      @url = "http://127.0.0.1:#{port}"
+      @worker = Patriot::Worker::MultiNodeWorker.new(@config)
+      @job1 = TestEnvironment.build_job({:job_id => "wait1"})
+      @job2 = TestEnvironment.build_job({:job_id => "wait2"})
+      @job3 = TestEnvironment.build_job({:job_id => "running",
+                                         :state => Patriot::JobStore::JobState::RUNNING})
+      @job4 = TestEnvironment.build_job({:job_id => "failed",
+                                         :state => Patriot::JobStore::JobState::FAILED})
+      @update_id = Time.now.to_i
+      @job_store = @worker.instance_variable_get(:@job_store)
+      @job_store.register(@update_id, [@job1,@job2,@job3,@job4])
+      @info_server = @worker.instance_variable_get(:@info_server)
+      @info_server.start_server
+      @client = RestClient::Resource.new("#{@url}/api/v1/jobs")
+      @client_auth = RestClient::Resource.new("#{@url}/api/v1/jobs", :user => "admin", :password => "password")
+
+      sleep 1
+    end
+
+    before :each do
+      @worker.instance_variable_set(:@status, Patriot::Worker::Status::ACTIVE)
+    end
+
+    after :all do
+      @info_server.shutdown_server
+    end
+
+
+    it "should get stats" do
+      expect(JSON.parse(@client["/stats"].get()
+      )).to match_array([
+        [Patriot::JobStore::JobState::INIT.to_s,    0],
+        [Patriot::JobStore::JobState::WAIT.to_s,    2],
+        [Patriot::JobStore::JobState::RUNNING.to_s, 1],
+        [Patriot::JobStore::JobState::SUSPEND.to_s, 0],
+        [Patriot::JobStore::JobState::FAILED.to_s,  1]
+      ])
+    end
+
+
+    it "should get jobs" do
+      expect(JSON.parse(@client.get()
+      )).to match_array([{"state" => Patriot::JobStore::JobState::FAILED,
+                          "job_id" => "sh_job_failed_2015-04-01"}])
+
+      expect(JSON.parse(@client.get(
+        {:params => {:state => Patriot::JobStore::JobState::RUNNING}}
+      ))).to match_array([{"state" => Patriot::JobStore::JobState::RUNNING,
+                           "job_id" => "sh_job_running_2015-04-01"}])
+
+      expect(JSON.parse(@client.get(
+        {:params => {:state => Patriot::JobStore::JobState::WAIT}}
+      ))).to match_array([{"state" => Patriot::JobStore::JobState::WAIT, "job_id" => "sh_job_wait1_2015-04-01"},
+                          {"state" => Patriot::JobStore::JobState::WAIT, "job_id" => "sh_job_wait2_2015-04-01"}])
+
+      # expect wait2 (since registered later than wait1)
+      expect(JSON.parse(@client.get(
+        {:params => {:state => Patriot::JobStore::JobState::WAIT,
+                     :limit => 1}}
+      ))).to match_array([{"state" => Patriot::JobStore::JobState::WAIT, "job_id" => "sh_job_wait2_2015-04-01"}])
+
+      expect(JSON.parse(@client.get(
+        {:params => {:state => Patriot::JobStore::JobState::WAIT,
+                     :limit => 1,
+                     :offset => 1}}
+      ))).to match_array([{"state" => Patriot::JobStore::JobState::WAIT, "job_id" => "sh_job_wait1_2015-04-01"}])
+
+      expect(JSON.parse(@client.get(
+        {:params => {:state => Patriot::JobStore::JobState::WAIT,
+                     :filter_exp => "%wait1%"}}
+      ))).to match_array([{"state" => Patriot::JobStore::JobState::WAIT, "job_id" => "sh_job_wait1_2015-04-01"}])
+    end
+
+
+    it "should not get any jobs" do
+      expect(JSON.parse(@client.get(
+        {:params => {:state => Patriot::JobStore::JobState::SUSPEND}}
+      ))).to match_array([])
+
+      expect(JSON.parse(@client.get(
+        {:params => {:state => Patriot::JobStore::JobState::WAIT,
+                     :limit => 0}}
+      ))).to match_array([])
+
+      expect(JSON.parse(@client.get(
+        {:params => {:state => Patriot::JobStore::JobState::WAIT,
+                     :offset => 2}}
+      ))).to match_array([])
+
+      expect(JSON.parse(@client.get(
+        {:params => {:state => Patriot::JobStore::JobState::WAIT,
+                     :filter_exp => "%never_match%"}}
+      ))).to match_array([])
+    end
+
+
+    it "should get the detail of a specified job" do
+      expect(JSON.parse(@client['/sh_job_wait1_2015-04-01'].get()
+      )).to include(
+        {
+          "COMMAND_CLASS" => "Patriot.Command.ShCommand",
+          "job_id"        => "sh_job_wait1_2015-04-01",
+          "priority"      => 1,
+          "state"         => Patriot::JobStore::JobState::WAIT
+        }
+      )
+    end
+
+
+    it "should add a new job" do
+      expect{JSON.parse(@client['/sh_newjob_2015-04-01'].get()
+      )}.to raise_error(RestClient::ResourceNotFound)
+
+      expect(JSON.parse(@client_auth.post(
+        JSON.generate({
+          "COMMAND_CLASS" => "Patriot.Command.ShCommand",
+          "name"          => "newjob",
+          "name_suffix"   => "2015-04-01",
+          "priority"      => 10,
+          "exec_node"     => "calc_node",
+          "exec_date"     => "2015-04-02",
+          "start_after"   => "01:30:00"
+        }),
+        {:content_type => :json}
+      ))).to eq({"job_id" => "sh_newjob_2015-04-01"})
+
+      expect(JSON.parse(@client['/sh_newjob_2015-04-01'].get()
+      )).to include(
+        {
+          "COMMAND_CLASS"  => "Patriot.Command.ShCommand",
+          "job_id"         => "sh_newjob_2015-04-01",
+          "priority"       => 10,
+          "state"          => Patriot::JobStore::JobState::WAIT,
+          "exec_node"      => "calc_node",
+          "start_datetime" => "2015-04-02 01:30:00 +0900"
+        }
+      )
+    end
+
+
+    it "should change the status of a specified job" do
+      expect(JSON.parse(@client['/sh_job_wait1_2015-04-01'].get()
+      )).to include({"job_id" => "sh_job_wait1_2015-04-01", "state" => Patriot::JobStore::JobState::WAIT})
+
+      expect(JSON.parse(@client_auth['/sh_job_wait1_2015-04-01'].put(
+        JSON.generate({:state => Patriot::JobStore::JobState::SUSPEND}), {:content_type => :json}
+      ))).to eq({"job_id" => "sh_job_wait1_2015-04-01", "state" => Patriot::JobStore::JobState::SUSPEND})
+
+      expect(JSON.parse(@client['/sh_job_wait1_2015-04-01'].get()
+      )).to include({"job_id" => "sh_job_wait1_2015-04-01", "state" => Patriot::JobStore::JobState::SUSPEND})
+
+      expect(JSON.parse(@client_auth['/sh_job_wait1_2015-04-01'].put(
+        JSON.generate({:state => Patriot::JobStore::JobState::WAIT}), {:content_type => :json}
+      ))).to include({"job_id" => "sh_job_wait1_2015-04-01", "state" => Patriot::JobStore::JobState::WAIT})
+
+      expect(JSON.parse(@client['/sh_job_wait1_2015-04-01'].get()
+      )).to include({"job_id" => "sh_job_wait1_2015-04-01", "state" => Patriot::JobStore::JobState::WAIT})
+    end
+
+
+    it "should delete a job" do
+      expect(JSON.parse(@client.get(
+        {:params => {:state => Patriot::JobStore::JobState::WAIT, :filter_exp => "%wait%"}}
+      ))).to match_array([{"state" => Patriot::JobStore::JobState::WAIT, "job_id" => "sh_job_wait1_2015-04-01"},
+                          {"state" => Patriot::JobStore::JobState::WAIT, "job_id" => "sh_job_wait2_2015-04-01"}])
+
+      expect(JSON.parse(@client_auth['/sh_job_wait2_2015-04-01'].delete())
+      ).to match_array({"job_id" => "sh_job_wait2_2015-04-01"})
+
+      expect(JSON.parse(@client.get(
+        {:params => {:state => Patriot::JobStore::JobState::WAIT, :filter_exp => "%wait%"}}
+      ))).to match_array([{"state" => Patriot::JobStore::JobState::WAIT, "job_id" => "sh_job_wait1_2015-04-01"}])
+    end
+
+
+    it "raises an error when calling get for detail with unexisting job_id" do
+      expect{@client['/sh_never_match_2015-04-01'].get()
+      }.to raise_error(RestClient::ResourceNotFound)
+    end
+
+    it "raises an error when calling put with unexisitng job_id" do
+      expect{@client_auth['/sh_never_match_2015-04-01'].put(
+        JSON.generate({:state => Patriot::JobStore::JobState::SUSPEND}), {:content_type => :json}
+      )}.to raise_error(RestClient::ResourceNotFound)
+    end
+
+    it "raises an error when callind delete with unexisting job_id" do
+      expect{@client_auth['/sh_never_match_2015-04-01'].delete()
+      }.to raise_error(RestClient::ResourceNotFound)
+    end
+
+
+    it "raises an error when calling post without auth" do
+      expect{@client.post(
+        JSON.generate({
+          "COMMAND_CLASS" => "Patriot.Command.ShCommand",
+          "name"          => "newjob"
+        }),
+        {:content_type => :json}
+      )}.to raise_error(RestClient::Unauthorized)
+    end
+
+    it "raises an error when calling put without auth" do
+      expect{@client['/sh_job_wait1_2015-04-01'].put(
+        JSON.generate({:state => Patriot::JobStore::JobState::SUSPEND}), {:content_type => :json}
+      )}.to raise_error(RestClient::Unauthorized)
+    end
+
+    it "raises an error when calling delete without auth" do
+      expect{@client['/sh_job_wait2_2015-04-01'].delete()}.to raise_error(RestClient::Unauthorized)
+    end
+  end
+end

--- a/spec/template/job_store_spec.erb
+++ b/spec/template/job_store_spec.erb
@@ -15,12 +15,12 @@ describe <%= job_store_class %> do
       @host = 'dummy_host1'
       @update_id = Time.now.to_i
       @job_store = <%= job_store_class %>.new("root", @config)
-      @anyjob  = TestEnvirionment.build_job({})
-      @nodejob = TestEnvirionment.build_job({:node => @node})
-      @hostjob = TestEnvirionment.build_job({:host => @host})
-      @bothjob = TestEnvirionment.build_job({:node => @node, :host => @host})
-      @p_job   = TestEnvirionment.build_job({:node => @node, :produce => ['p']})
-      @c_job   = TestEnvirionment.build_job({:node => @node, :require => ['p']})
+      @anyjob  = TestEnvironment.build_job({})
+      @nodejob = TestEnvironment.build_job({:node => @node})
+      @hostjob = TestEnvironment.build_job({:host => @host})
+      @bothjob = TestEnvironment.build_job({:node => @node, :host => @host})
+      @p_job   = TestEnvironment.build_job({:node => @node, :produce => ['p']})
+      @c_job   = TestEnvironment.build_job({:node => @node, :require => ['p']})
       @job_store.register(@update_id, [@anyjob, @nodejob, @hostjob, @bothjob, @p_job,@c_job])
     end
 
@@ -55,9 +55,9 @@ describe <%= job_store_class %> do
     it "should include dependency" do 
       job = @job_store.get(@c_job.job_id, :include_dependency=>true)
       expect(job['consumers']).to be_empty
-      expect(job['producers'].keys).to contain_exactly(@p_job.job_id)
+      expect(job['producers']).to contain_exactly({"job_id" => @p_job.job_id, "state" => 1})
       job = @job_store.get(@p_job.job_id, :include_dependency=>true)
-      expect(job['consumers'].keys).to contain_exactly(@c_job.job_id)
+      expect(job['consumers']).to contain_exactly({"job_id" => @c_job.job_id, "state" => 1})
       expect(job['producers']).to be_empty
     end
 
@@ -74,7 +74,7 @@ describe <%= job_store_class %> do
       it "should return producers" do
         producers = @job_store.get_producers("p")
         expect(producers.size).to eq 1
-        expect(producers.has_key?(@p_job.job_id)).to eq true
+        expect(producers.map{|p| p["job_id"]}).to contain_exactly(@p_job.job_id)
       end
     end
 
@@ -82,7 +82,7 @@ describe <%= job_store_class %> do
       it "should return consumers" do
         consumers = @job_store.get_consumers("p")
         expect(consumers.size).to eq 1
-        expect(consumers.has_key?(@c_job.job_id)).to be true
+        expect(consumers.map{|c| c["job_id"]}).to contain_exactly(@c_job.job_id)
       end
     end
   end
@@ -92,11 +92,11 @@ describe <%= job_store_class %> do
       @update_id = Time.now.to_i
       @job_store = <%= job_store_class %>.new("root", @config)
       # set state to suspend to avoid effects of other tests
-      @job1 = TestEnvirionment.build_job({:job_id => 'j1', :state => Patriot::JobStore::JobState::SUSPEND})
-      @job2 = TestEnvirionment.build_job({:job_id => 'j2', :state => Patriot::JobStore::JobState::FAILED})
-      @job3 = TestEnvirionment.build_job({:job_id => 'j3', :state => Patriot::JobStore::JobState::FAILED})
-      @job4 = TestEnvirionment.build_job({:job_id => 'j4', :state => Patriot::JobStore::JobState::SUSPEND, :produce => ['p']})
-      @job5 = TestEnvirionment.build_job({:job_id => 'j5', :state => Patriot::JobStore::JobState::SUSPEND, :require => ['p']})
+      @job1 = TestEnvironment.build_job({:job_id => 'j1', :state => Patriot::JobStore::JobState::SUSPEND})
+      @job2 = TestEnvironment.build_job({:job_id => 'j2', :state => Patriot::JobStore::JobState::FAILED})
+      @job3 = TestEnvironment.build_job({:job_id => 'j3', :state => Patriot::JobStore::JobState::FAILED})
+      @job4 = TestEnvironment.build_job({:job_id => 'j4', :state => Patriot::JobStore::JobState::SUSPEND, :produce => ['p']})
+      @job5 = TestEnvironment.build_job({:job_id => 'j5', :state => Patriot::JobStore::JobState::SUSPEND, :require => ['p']})
       @job_store.register(@update_id, [@job1, @job2, @job3, @job4, @job5])
     end
 
@@ -142,12 +142,12 @@ describe <%= job_store_class %> do
       @node      = 'dummy_node'
       @host      = 'dummy_host'
       @job_store = <%= job_store_class %>.new("root", @config)
-      @job       = TestEnvirionment.build_job({})
+      @job       = TestEnvironment.build_job({})
       @job_ticket = Patriot::JobStore::JobTicket.new(@job.job_id, @update_id)
-      @skip_on_fail_job        = TestEnvirionment.build_job({:post_processors => [Patriot::Command::PostProcessor::SkipOnFail.new]})
+      @skip_on_fail_job        = TestEnvironment.build_job({:post_processors => [Patriot::Command::PostProcessor::SkipOnFail.new]})
       @skip_on_fail_job_ticket = Patriot::JobStore::JobTicket.new(@skip_on_fail_job.job_id, @update_id)
-      @p_job     = TestEnvirionment.build_job({:job_id => 'with_node', :node => @node, :produce => ['p']})
-      @c_job     = TestEnvirionment.build_job({:job_id => 'with_host', :host => @host, :require => ['p']})
+      @p_job     = TestEnvironment.build_job({:job_id => 'with_node', :node => @node, :produce => ['p']})
+      @c_job     = TestEnvironment.build_job({:job_id => 'with_host', :host => @host, :require => ['p']})
       @job_store.register(@update_id, [@job, @skip_on_fail_job,  @p_job, @c_job])
     end
 
@@ -160,12 +160,12 @@ describe <%= job_store_class %> do
 
     it "should reregister job with keeping state" do
       update_id = Time.now.to_i
-      c_job     = TestEnvirionment.build_job({:job_id => 'with_host', :host => @host, :require => ['p']})
+      c_job     = TestEnvironment.build_job({:job_id => 'with_host', :host => @host, :require => ['p']})
       c_job[Patriot::Command::STATE_ATTR] = Patriot::JobStore::JobState::SUSPEND
       @job_store.register(update_id, [c_job])
       c_job = @job_store.get(@c_job.job_id)
       expect(c_job[Patriot::Command::STATE_ATTR]).to eq Patriot::JobStore::JobState::SUSPEND
-      c_job     = TestEnvirionment.build_job({:job_id => 'with_host', :host => @host, :require => ['p']})
+      c_job     = TestEnvironment.build_job({:job_id => 'with_host', :host => @host, :require => ['p']})
       c_job.delete(Patriot::Command::STATE_ATTR)
       @job_store.register(update_id, [c_job])
       c_job = @job_store.get(@c_job.job_id)
@@ -177,7 +177,7 @@ describe <%= job_store_class %> do
       job = @job_store.get(@p_job.job_id)
       expect(job[Patriot::Command::EXEC_NODE_ATTR]).to eq @node
       expect(job[Patriot::Command::PRIORITY_ATTR]).to eq Patriot::JobStore::DEFAULT_PRIORITY
-      job = TestEnvirionment.build_job({:job_id => 'with_node', :produce => ['p']})
+      job = TestEnvironment.build_job({:job_id => 'with_node', :produce => ['p']})
       @job_store.register(update_id, [job])
       job = @job_store.get(@p_job.job_id)
       expect(job[Patriot::Command::EXEC_NODE_ATTR]).to be nil
@@ -187,7 +187,7 @@ describe <%= job_store_class %> do
       job = @job_store.get(@c_job.job_id)
       expect(job[Patriot::Command::EXEC_HOST_ATTR]).to eq @host
       expect(job[Patriot::Command::PRIORITY_ATTR]).to eq Patriot::JobStore::DEFAULT_PRIORITY
-      job = TestEnvirionment.build_job({:job_id => 'with_host', :require => ['c']})
+      job = TestEnvironment.build_job({:job_id => 'with_host', :require => ['c']})
       @job_store.register(update_id, [job])
       job = @job_store.get(@c_job.job_id)
       expect(job[Patriot::Command::EXEC_HOST_ATTR]).to be nil
@@ -265,17 +265,17 @@ describe <%= job_store_class %> do
 
     it "should delete a consumer job from db" do
       job_id = @c_job.job_id
-      expect(@job_store.get(@p_job.job_id, {:include_dependency => true})['consumers'].keys).to include(job_id)
+      expect(@job_store.get(@p_job.job_id, {:include_dependency => true})['consumers'].map{|c| c["job_id"]}).to include(job_id)
       @job_store.delete_job(job_id)
-      expect(@job_store.get(@p_job.job_id, {:include_dependency => true})['consumers'].keys).not_to include(job_id)
+      expect(@job_store.get(@p_job.job_id, {:include_dependency => true})['consumers'].map{|c| c["job_id"]}).not_to include(job_id)
       expect(@job_store.get(job_id)).to be nil
     end
 
     it "should delete a producer job from db" do
       job_id = @p_job.job_id
-      expect(@job_store.get(@c_job.job_id, {:include_dependency => true})['producers'].keys).to include(job_id)
+      expect(@job_store.get(@c_job.job_id, {:include_dependency => true})['producers'].map{|p| p["job_id"]}).to include(job_id)
       @job_store.delete_job(job_id)
-      expect(@job_store.get(@c_job.job_id, {:include_dependency => true})['producers'].keys).not_to include(job_id)
+      expect(@job_store.get(@c_job.job_id, {:include_dependency => true})['producers'].map{|p| p["job_id"]}).not_to include(job_id)
       expect(@job_store.get(job_id)).to be nil
     end
 
@@ -304,8 +304,8 @@ EOJ
       @job_store = <%= job_store_class %>.new("root", @config)
     end
 
-    it "sholud not destroy input to be retriable" do
-      job = TestEnvirionment.build_job({:job_id => 'p1', :command => 'echo \'p1\'', :node => 'node'})
+    it "should not destroy input to be retriable" do
+      job = TestEnvironment.build_job({:job_id => 'p1', :command => 'echo \'p1\'', :node => 'node'})
       job_id = job.job_id
       expect(job[Patriot::Command::EXEC_NODE_ATTR]).to eq 'node'
       @job_store.register(Time.now.to_i, [job])
@@ -318,42 +318,42 @@ EOJ
   describe 'dependency management' do
     before :each do
       @job_store = <%= job_store_class %>.new("root", @config)
-      @producer1 = TestEnvirionment.build_job({:job_id => 'p1', :command => 'echo \'p1\'', :produce => ['1']})
-      @consumer1 = TestEnvirionment.build_job({:job_id => 'c1', :command => 'echo \'c1\'', :require => ['1']})
-      @producer2 = TestEnvirionment.build_job({:job_id => 'p2', :command => 'echo \'p2\'', :produce => ['2']})
-      @consumer2 = TestEnvirionment.build_job({:job_id => 'c2', :command => 'echo \'c2\'', :require => ['2']})
+      @producer1 = TestEnvironment.build_job({:job_id => 'p1', :command => 'echo \'p1\'', :produce => ['1']})
+      @consumer1 = TestEnvironment.build_job({:job_id => 'c1', :command => 'echo \'c1\'', :require => ['1']})
+      @producer2 = TestEnvironment.build_job({:job_id => 'p2', :command => 'echo \'p2\'', :produce => ['2']})
+      @consumer2 = TestEnvironment.build_job({:job_id => 'c2', :command => 'echo \'c2\'', :require => ['2']})
       jobs = [@producer1,@producer2,@consumer1,@consumer2]
       @job_store.register(Time.now.to_i, jobs)
     end
 
-    it "sholud not destroy dependency when producers are reregistered" do
-      jobs = [TestEnvirionment.build_job({:job_id => 'p1', :command => 'echo \'p1\'', :produce => ['1']})]
+    it "should not destroy dependency when producers are reregistered" do
+      jobs = [TestEnvironment.build_job({:job_id => 'p1', :command => 'echo \'p1\'', :produce => ['1']})]
       @job_store.register(Time.now.to_i, jobs)
       job = @job_store.get(@producer1.job_id, :include_dependency => true)
-      expect(job['consumers'].keys).to include(@consumer1.job_id)
+      expect(job['consumers'].map{|c| c["job_id"]}).to include(@consumer1.job_id)
     end
 
-    it "sholud remove the deprecated dependency " do
-      consumer2 = TestEnvirionment.build_job({:job_id => 'c2', :command => 'echo \'c2\'', :require => ['2']})
+    it "should remove the deprecated dependency " do
+      consumer2 = TestEnvironment.build_job({:job_id => 'c2', :command => 'echo \'c2\'', :require => ['2']})
       consumer2['requisites'] << "1"
       consumer2['requisites'].delete("2")
       jobs = [consumer2]
       @job_store.register(Time.now.to_i, jobs)
       job = @job_store.get(@producer2.job_id, :include_dependency => true)
-      expect(job['consumers']).not_to include(@consumer2.job_id)
+      expect(job['consumers'].map{|c| c["job_id"]}).not_to include(@consumer2.job_id)
       job = @job_store.get(@producer1.job_id, :include_dependency => true)
-      expect(job['consumers']).to include(@consumer2.job_id)
+      expect(job['consumers'].map{|c| c["job_id"]}).to include(@consumer2.job_id)
     end
 
-    it "sholud clear dependency " do
-      consumer1 = TestEnvirionment.build_job({:job_id => 'c1', :command => 'echo \'c1\''})
+    it "should clear dependency " do
+      consumer1 = TestEnvironment.build_job({:job_id => 'c1', :command => 'echo \'c1\''})
       consumer1['requisites'] = []
       jobs = [consumer1]
       @job_store.register(Time.now.to_i, jobs)
       job = @job_store.get(@producer1.job_id, :include_dependency => true)
       expect(job['consumers']).not_to include(@consumer1.job_id)
 
-      consumer2 = TestEnvirionment.build_job({:job_id => 'c2', :command => 'echo \'c2\''})
+      consumer2 = TestEnvironment.build_job({:job_id => 'c2', :command => 'echo \'c2\''})
       consumer2['requisites'] = nil
       jobs = [consumer2]
       @job_store.register(Time.now.to_i, jobs)


### PR DESCRIPTION
Adding the REST API to patriot-workflow-scheduler is underway, in order to manage its data from outside in a flexible way. (Thanks to @zenmyo 's support!)

Any advice would be appreciated, especially for the POST method to add a new job.