### PR TITLE
Add the content type application/json to api_servlet_base

### DIFF
--- a/lib/patriot/worker/servlet/api_servlet_base.rb
+++ b/lib/patriot/worker/servlet/api_servlet_base.rb
@@ -31,6 +31,9 @@ module Patriot
           @@password  = config.get(Patriot::Util::Config::PASSWORD_KEY, "")
         end
 
+        before do
+          content_type 'application/json;charset=utf8'
+        end
       end
     end
   end

--- a/spec/patriot/worker/servlet/job_api_servlet_spec.rb
+++ b/spec/patriot/worker/servlet/job_api_servlet_spec.rb
@@ -38,6 +38,12 @@ describe Patriot::Worker::Servlet::JobAPIServlet do
     end
 
 
+    it "should get a response with application/json" do
+      expect(@client["/stats"].get().headers[:content_type]
+      ).to eq("application/json;charset=utf8")
+    end
+
+
     it "should get stats" do
       expect(JSON.parse(@client["/stats"].get()
       )).to match_array([

--- a/spec/patriot/worker/servlet/worker_api_servlet_spec.rb
+++ b/spec/patriot/worker/servlet/worker_api_servlet_spec.rb
@@ -27,6 +27,11 @@ describe Patriot::Worker::Servlet::JobAPIServlet do
       @info_server.shutdown_server
     end
 
+    it "should get a response with application/json" do
+      expect(@client["/"].get().headers[:content_type]
+      ).to eq("application/json;charset=utf8")
+    end
+
     it "should get list of workers" do
       expect(JSON.parse(@client["/"].get()
       )).to contain_exactly(


### PR DESCRIPTION
Add the content type application/json to api_servlet_base so that clients can handle the response with JSON format.