### PR TITLE
Force load_to_bigquery params to be set in pbc files

### DIFF
--- a/plugins/patriot-gcp/lib/patriot_gcp/command/load_to_bigquery.rb
+++ b/plugins/patriot-gcp/lib/patriot_gcp/command/load_to_bigquery.rb
@@ -5,34 +5,32 @@ module PatriotGCP
       include PatriotGCP::Ext::BigQuery
 
       command_attr :inifile, :project_id, :dataset, :table, :schema, :options, :input_file, :name_suffix, :polling_interval
+      validate_existence :inifile, :project_id, :dataset, :table
 
       class BigQueryException < Exception; end
       class GoogleCloudPlatformException < Exception; end
 
       def job_id
-        job_id = "#{command_name}_#{@project_id}_#{@dataset}_#{@table}"
-        job_id = "#{job_id}_#{@name_suffix}" unless @name_suffix.nil?
-        return job_id
+        "#{command_name}_#{@project_id}_#{@dataset}_#{@table}_#{@name_suffix}"
       end
 
       # @see Patriot::Command::Base#configure
       def configure
+        @name_suffix ||= _date_
+        self
+      end
+
+      def execute
+        @logger.info "start load_to_bigquery"
+
         ini = IniFile.load(@inifile)
         if ini.nil?
           raise Exception, "inifile not found"
         end
 
-        @service_account  = ini["gcp"]["service_account"]
-        @private_key      = ini["gcp"]["private_key"]
-        @key_pass         = ini["gcp"]["key_pass"]
-        @project_id     ||= ini["bigquery"]["project_id"]
-        @dataset        ||= ini["bigquery"]["dataset"]
-
-        return self
-      end
-
-      def execute
-        @logger.info "start load_to_bigquery"
+        service_account  = ini["gcp"]["service_account"]
+        private_key      = ini["gcp"]["private_key"]
+        key_pass         = ini["gcp"]["key_pass"]
 
         unless File.exist?(@input_file)
           raise Exception, "The given file doesn't exist."
@@ -43,17 +41,15 @@ module PatriotGCP
           return
         end
 
-        if @service_account.nil? or @private_key.nil?
+        if service_account.nil? or private_key.nil?
           raise GoogleCloudPlatformException, "configuration for GCP is not enough."
-        elsif @project_id.nil? or @dataset.nil?
-          raise BigQueryException, "configuration for BigQuery is not enough."
         end
 
         @logger.info "start uploading"
         stat_info = bq_load(@input_file,
-                            @private_key,
-                            @key_pass,
-                            @service_account,
+                            private_key,
+                            key_pass,
+                            service_account,
                             @project_id,
                             @dataset,
                             @table,

--- a/plugins/patriot-gcp/lib/patriot_gcp/version.rb
+++ b/plugins/patriot-gcp/lib/patriot_gcp/version.rb
@@ -1,4 +1,4 @@
 class VERSION
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
   PROJECT_NAME = "patriot-gcp"
 end

--- a/plugins/patriot-gcp/spec/config/test-bigquery-with-dataset.ini
+++ b/plugins/patriot-gcp/spec/config/test-bigquery-with-dataset.ini
@@ -1,7 +1,0 @@
-[gcp]
-service_account = test-account@developer.gserviceaccount.com
-private_key = /path/to/keyfile
-key_pass = key_pass
-
-[bigquery]
-dataset = test-dataset

--- a/plugins/patriot-gcp/spec/config/test-bigquery-with-project_id-and-dataset.ini
+++ b/plugins/patriot-gcp/spec/config/test-bigquery-with-project_id-and-dataset.ini
@@ -1,8 +1,0 @@
-[gcp]
-service_account = test-account@developer.gserviceaccount.com
-private_key = /path/to/keyfile
-key_pass = key_pass
-
-[bigquery]
-project_id = test-project
-dataset = test-dataset

--- a/plugins/patriot-gcp/spec/config/test-bigquery-with-project_id.ini
+++ b/plugins/patriot-gcp/spec/config/test-bigquery-with-project_id.ini
@@ -1,7 +1,0 @@
-[gcp]
-service_account = test-account@developer.gserviceaccount.com
-private_key = /path/to/keyfile
-key_pass = key_pass
-
-[bigquery]
-project_id = test-project

--- a/plugins/patriot-gcp/spec/config/test-bigquery-without-project_id-and-dataset.ini
+++ b/plugins/patriot-gcp/spec/config/test-bigquery-without-project_id-and-dataset.ini
@@ -1,6 +1,0 @@
-[gcp]
-service_account = test-account@developer.gserviceaccount.com
-private_key = /path/to/keyfile
-key_pass = key_pass
-
-[bigquery]

--- a/plugins/patriot-gcp/spec/config/test-bigquery.ini
+++ b/plugins/patriot-gcp/spec/config/test-bigquery.ini
@@ -2,6 +2,3 @@
 service_account = test-account@developer.gserviceaccount.com
 private_key = /path/to/keyfile
 key_pass = key_pass
-
-[bigquery]
-project_id = test-project

--- a/plugins/patriot-gcp/spec/patriot_gcp/command/load_to_bigquery_spec.rb
+++ b/plugins/patriot-gcp/spec/patriot_gcp/command/load_to_bigquery_spec.rb
@@ -2,16 +2,111 @@ require "init_test"
 require 'erb'
 include Patriot::Command::Parser
 
-describe PatriotGCP::Command::LoadToBigQueryCommand do  
+describe PatriotGCP::Command::LoadToBigQueryCommand do
   before :all do
     @target_datetime = DateTime.new(2011,12,12)
     @config = config_for_test
   end 
 
+  describe 'job_id' do
+    it 'should get job_id' do
+      cmd = new_command(PatriotGCP::Command::LoadToBigQueryCommand) do
+        inifile path_to_test_config('test-bigquery.ini')
+        project_id 'test-project_id'
+        dataset 'test-dataset'
+        table 'test-table'
+        schema 'field1'
+        input_file File.join(SAMPLE_DIR, 'hive_result.txt')
+        options 'fieldDelimiter' => '\t',
+                'writeDisposition' => 'WRITE_APPEND',
+                'allowLargeResults' => true
+        polling_interval 30
+      end
+      cmd = cmd.build[0]
+
+      expect(cmd.job_id).to eq('loadtobigquery_test-project_id_test-dataset_test-table_2011-12-12')
+    end
+  end
+
+  describe 'configure' do
+    it 'should raise an error when inifile is not set' do
+      cmd = new_command(PatriotGCP::Command::LoadToBigQueryCommand) do
+        project_id 'test-project_id'
+        dataset 'test-dataset'
+        table 'test-table'
+        schema 'field1'
+        input_file File.join(SAMPLE_DIR, 'hive_result.txt')
+        options 'fieldDelimiter' => '\t',
+                'writeDisposition' => 'WRITE_APPEND',
+                'allowLargeResults' => true
+        polling_interval 30
+      end
+      expect { cmd.build[0] }.to raise_error(
+        RuntimeError,
+        'validation error : inifile= (PatriotGCP::Command::LoadToBigQueryCommand)'
+      )
+    end
+
+    it 'should raise an error when project_id is not set' do
+      cmd = new_command(PatriotGCP::Command::LoadToBigQueryCommand) do
+        inifile path_to_test_config('test-bigquery.ini')
+        dataset 'test-dataset'
+        table 'test-table'
+        schema 'field1'
+        input_file File.join(SAMPLE_DIR, 'hive_result.txt')
+        options 'fieldDelimiter' => '\t',
+                'writeDisposition' => 'WRITE_APPEND',
+                'allowLargeResults' => true
+        polling_interval 30
+      end
+      expect { cmd.build[0] }.to raise_error(
+        RuntimeError,
+        'validation error : project_id= (PatriotGCP::Command::LoadToBigQueryCommand)'
+      )
+    end
+
+    it 'should raise an error when dataset is not set' do
+      cmd = new_command(PatriotGCP::Command::LoadToBigQueryCommand) do
+        inifile path_to_test_config('test-bigquery.ini')
+        project_id 'test-project_id'
+        table 'test-table'
+        schema 'field1'
+        input_file File.join(SAMPLE_DIR, 'hive_result.txt')
+        options 'fieldDelimiter' => '\t',
+                'writeDisposition' => 'WRITE_APPEND',
+                'allowLargeResults' => true
+        polling_interval 30
+      end
+      expect { cmd.build[0] }.to raise_error(
+        RuntimeError,
+        'validation error : dataset= (PatriotGCP::Command::LoadToBigQueryCommand)'
+      )
+    end
+
+    it 'should raise an error when table is not set' do
+      cmd = new_command(PatriotGCP::Command::LoadToBigQueryCommand) do
+        inifile path_to_test_config('test-bigquery.ini')
+        project_id 'test-project_id'
+        dataset 'test-dataset'
+        schema 'field1'
+        input_file File.join(SAMPLE_DIR, 'hive_result.txt')
+        options 'fieldDelimiter' => '\t',
+                'writeDisposition' => 'WRITE_APPEND',
+                'allowLargeResults' => true
+        polling_interval 30
+      end
+      expect { cmd.build[0] }.to raise_error(
+        RuntimeError,
+        'validation error : table= (PatriotGCP::Command::LoadToBigQueryCommand)'
+      )
+    end
+  end
+
   it "should work" do
     allow_any_instance_of(PatriotGCP::Ext::BigQuery).to receive(:bq_load)
     cmd = new_command(PatriotGCP::Command::LoadToBigQueryCommand) do  
       inifile path_to_test_config('test-bigquery.ini')
+      project_id 'test-project_id'
       dataset 'test-dataset'
       table 'test-table'
       schema 'field1'
@@ -29,6 +124,7 @@ describe PatriotGCP::Command::LoadToBigQueryCommand do
     allow_any_instance_of(PatriotGCP::Ext::BigQuery).to receive(:bq_load)
     cmd = new_command(PatriotGCP::Command::LoadToBigQueryCommand) do
       inifile path_to_test_config('test-bigquery.ini')
+      project_id 'test-project_id'
       dataset 'test-dataset'
       table 'test-table'
       schema 'field1'
@@ -42,6 +138,7 @@ describe PatriotGCP::Command::LoadToBigQueryCommand do
     allow_any_instance_of(PatriotGCP::Ext::BigQuery).to receive(:bq_load)
     cmd = new_command(PatriotGCP::Command::LoadToBigQueryCommand) do  
       inifile path_to_test_config('test-bigquery.ini')
+      project_id 'test-project_id'
       dataset 'test-dataset'
       table 'test-table'
       schema 'field1'
@@ -53,167 +150,14 @@ describe PatriotGCP::Command::LoadToBigQueryCommand do
     cmd = cmd.build[0]
     cmd = cmd.to_job.to_command(@config)
 
-    cmd.configure
     cmd.execute
-  end 
-
-  it "should raise an error with ini(set:project_id) and pbc(set:none)" do
-    allow_any_instance_of(PatriotGCP::Ext::BigQuery).to receive(:bq_load)
-    cmd = new_command(PatriotGCP::Command::LoadToBigQueryCommand) do  
-      inifile path_to_test_config('test-bigquery-with-project_id.ini')
-      table 'test-table'
-      schema 'field1'
-      input_file File.join(SAMPLE_DIR, "hive_result.txt")
-    end 
-    cmd = cmd.build[0]
-    expect{cmd.execute}.to raise_error(
-      PatriotGCP::Command::LoadToBigQueryCommand::BigQueryException,
-      "configuration for BigQuery is not enough."
-    )
-  end 
-
-  it "should raise an error with ini(set:dataset) and pbc(set:none)" do
-    allow_any_instance_of(PatriotGCP::Ext::BigQuery).to receive(:bq_load)
-    cmd = new_command(PatriotGCP::Command::LoadToBigQueryCommand) do  
-      inifile path_to_test_config('test-bigquery-with-dataset.ini')
-      table 'test-table'
-      schema 'field1'
-      input_file File.join(SAMPLE_DIR, "hive_result.txt")
-    end 
-    cmd = cmd.build[0]
-    expect{cmd.execute}.to raise_error(
-      PatriotGCP::Command::LoadToBigQueryCommand::BigQueryException,
-      "configuration for BigQuery is not enough."
-    )
-  end 
-
-  it "should raise an error with ini(set:none) and pbc(set:project_id)" do
-    allow_any_instance_of(PatriotGCP::Ext::BigQuery).to receive(:bq_load)
-    cmd = new_command(PatriotGCP::Command::LoadToBigQueryCommand) do  
-      inifile path_to_test_config('test-bigquery-without-project_id-and-dataset.ini')
-      project_id 'test-project'
-      table 'test-table'
-      schema 'field1'
-      input_file File.join(SAMPLE_DIR, "hive_result.txt")
-    end 
-    cmd = cmd.build[0]
-    expect{cmd.execute}.to raise_error(
-      PatriotGCP::Command::LoadToBigQueryCommand::BigQueryException,
-      "configuration for BigQuery is not enough."
-    )
-  end 
-
-  it "should raise an error with ini(set:none) and pbc(set:dataset)" do
-    allow_any_instance_of(PatriotGCP::Ext::BigQuery).to receive(:bq_load)
-    cmd = new_command(PatriotGCP::Command::LoadToBigQueryCommand) do  
-      inifile path_to_test_config('test-bigquery-without-project_id-and-dataset.ini')
-      dataset 'test-dataset'
-      table 'test-table'
-      schema 'field1'
-      input_file File.join(SAMPLE_DIR, "hive_result.txt")
-    end 
-    cmd = cmd.build[0]
-    expect{cmd.execute}.to raise_error(
-      PatriotGCP::Command::LoadToBigQueryCommand::BigQueryException,
-      "configuration for BigQuery is not enough."
-    )
-  end 
-
-  it "should raise an error with ini(set:none) and pbc(set:none)" do
-    allow_any_instance_of(PatriotGCP::Ext::BigQuery).to receive(:bq_load)
-    cmd = new_command(PatriotGCP::Command::LoadToBigQueryCommand) do  
-      inifile path_to_test_config('test-bigquery-without-project_id-and-dataset.ini')
-      table 'test-table'
-      schema 'field1'
-      input_file File.join(SAMPLE_DIR, "hive_result.txt")
-    end 
-    cmd = cmd.build[0]
-    expect{cmd.execute}.to raise_error(
-      PatriotGCP::Command::LoadToBigQueryCommand::BigQueryException,
-      "configuration for BigQuery is not enough."
-    )
-  end 
-
-  it "should work with ini(set:none) and pbc(set:project_id, dataset)" do
-    allow_any_instance_of(PatriotGCP::Ext::BigQuery).to receive(:bq_load)
-    cmd = new_command(PatriotGCP::Command::LoadToBigQueryCommand) do  
-      inifile path_to_test_config('test-bigquery-without-project_id-and-dataset.ini')
-      project_id 'test-project-pbc'
-      dataset 'test-dataset-pbc'
-      table 'test-table'
-      schema 'field1'
-      input_file File.join(SAMPLE_DIR, "hive_result.txt")
-    end 
-    cmd = cmd.build[0]
-    cmd.execute
-    expect(cmd.instance_variable_get(:@project_id)).to eq('test-project-pbc')
-    expect(cmd.instance_variable_get(:@dataset)).to eq('test-dataset-pbc')
-  end 
-
-  it "should work with ini(set:project_id, dataset) and pbc(set:none)" do
-    allow_any_instance_of(PatriotGCP::Ext::BigQuery).to receive(:bq_load)
-    cmd = new_command(PatriotGCP::Command::LoadToBigQueryCommand) do  
-      inifile path_to_test_config('test-bigquery-with-project_id-and-dataset.ini')
-      table 'test-table'
-      schema 'field1'
-      input_file File.join(SAMPLE_DIR, "hive_result.txt")
-    end 
-    cmd = cmd.build[0]
-    cmd.execute
-    expect(cmd.instance_variable_get(:@project_id)).to eq('test-project')
-    expect(cmd.instance_variable_get(:@dataset)).to eq('test-dataset')
-  end 
-
-  it "should work with ini(set:project_id) and pbc(set:dataset)" do
-    allow_any_instance_of(PatriotGCP::Ext::BigQuery).to receive(:bq_load)
-    cmd = new_command(PatriotGCP::Command::LoadToBigQueryCommand) do  
-      inifile path_to_test_config('test-bigquery-with-project_id.ini')
-      dataset 'test-dataset-pbc'
-      table 'test-table'
-      schema 'field1'
-      input_file File.join(SAMPLE_DIR, "hive_result.txt")
-    end 
-    cmd = cmd.build[0]
-    cmd.execute
-    expect(cmd.instance_variable_get(:@project_id)).to eq('test-project')
-    expect(cmd.instance_variable_get(:@dataset)).to eq('test-dataset-pbc')
-  end 
-
-  it "should work with ini(set:dataset) and pbc(set:project_id)" do
-    allow_any_instance_of(PatriotGCP::Ext::BigQuery).to receive(:bq_load)
-    cmd = new_command(PatriotGCP::Command::LoadToBigQueryCommand) do  
-      inifile path_to_test_config('test-bigquery-with-dataset.ini')
-      project_id 'test-project-pbc'
-      table 'test-table'
-      schema 'field1'
-      input_file File.join(SAMPLE_DIR, "hive_result.txt")
-    end 
-    cmd = cmd.build[0]
-    cmd.execute
-    expect(cmd.instance_variable_get(:@project_id)).to eq('test-project-pbc')
-    expect(cmd.instance_variable_get(:@dataset)).to eq('test-dataset')
-  end 
-
-  it "should have priority in pbc settings with ini(set:project_id, dataset) and pbc(set:project_id, dataset)" do
-    allow_any_instance_of(PatriotGCP::Ext::BigQuery).to receive(:bq_load)
-    cmd = new_command(PatriotGCP::Command::LoadToBigQueryCommand) do  
-      inifile path_to_test_config('test-bigquery-with-project_id-and-dataset.ini')
-      project_id 'test-project-pbc'
-      dataset 'test-dataset-pbc'
-      table 'test-table'
-      schema 'field1'
-      input_file File.join(SAMPLE_DIR, "hive_result.txt")
-    end 
-    cmd = cmd.build[0]
-    cmd.execute
-    expect(cmd.instance_variable_get(:@project_id)).to eq('test-project-pbc')
-    expect(cmd.instance_variable_get(:@dataset)).to eq('test-dataset-pbc')
   end 
 
   it "should raise an error when the given file doesn't exist" do
     allow_any_instance_of(PatriotGCP::Ext::BigQuery).to receive(:bq_load)
     cmd = new_command(PatriotGCP::Command::LoadToBigQueryCommand) do  
       inifile path_to_test_config('test-bigquery.ini')
+      project_id 'test-project_id'
       dataset 'test-dataset'
       table 'test-table'
       schema 'field1'
@@ -230,6 +174,7 @@ describe PatriotGCP::Command::LoadToBigQueryCommand do
     allow_any_instance_of(PatriotGCP::Ext::BigQuery).to receive(:bq_load)
     cmd = new_command(PatriotGCP::Command::LoadToBigQueryCommand) do  
       inifile 'UNEXIST FILE'
+      project_id 'test-project_id'
       dataset 'test-dataset'
       table 'test-table'
       schema 'field1'
@@ -238,6 +183,8 @@ describe PatriotGCP::Command::LoadToBigQueryCommand do
               'writeDisposition' => 'WRITE_APPEND',
               'allowLargeResults' => true
     end 
-    expect{cmd.build[0]}.to raise_error(Exception, "inifile not found")
+    cmd = cmd.build[0]
+
+    expect { cmd.execute }.to raise_error(Exception, 'inifile not found')
   end 
 end


### PR DESCRIPTION
The following parameters are needed to be set in pbc files,
because the parameters should be checked and job_id should be
determined at client side when registering jobs.

* project_id
* dataset
* table