### PR TITLE
[WIP]Avoid ERROR: No such file or directory @ rb_sysopen public/views/index.erb

### DIFF
--- a/skel/public/views/index.erb
+++ b/skel/public/views/index.erb
@@ -1,0 +1,13 @@
+<html>
+<head>
+<title>Home</title>
+<link rel="stylesheet" href="<%= url('css/bootstrap.min.css') %>">
+<link rel="stylesheet" href="<%= url('css/original.css') %>">
+</head>
+<body>
+  <div id="mainContent">
+    <script src="<%= url('js/patriot-workflow-scheduler-0.8.0.js') %>"></script>
+  </div>
+</body>
+</html>
+


### PR DESCRIPTION
This error occurs when accessing http://localhost:36104/.

This error occurs not when building patriot-workflow-scheduler from source but when installing patriot-workflow-scheduler by gem install.

index.tpl.erb is supposed to be separated by dev/prd environments, but I gave priority to avoid this error.