### PR TITLE
Won't use '%' when searching job_ids in web console.

### DIFF
--- a/docs/source/web.rst
+++ b/docs/source/web.rst
@@ -25,7 +25,6 @@ Each job can be in one of following states.
 
       The web console has a capability for filtering jobs by job_id.
       The filter searches jobs by complete match.
-      If you want to search jobs with job_ids prefixed with 'prefix', the filter should be set as 'prefix%'.
 
   * Discarded State
 

--- a/lib/patriot/job_store/rdb_job_store.rb
+++ b/lib/patriot/job_store/rdb_job_store.rb
@@ -401,7 +401,7 @@ END_OB_QUERY
       def find_jobs_by_state(state, opts = {})
         raise "OFFSET is set WITHOUT LIMIT" if opts.has_key?(:offset) && !opts.has_key?(:limit)
         condition = ["state = #{state}", "id != #{@initiator_id}"]
-        condition |= ["job_id LIKE '%#{opts[:filter_exp]}%'"] if opts.has_key?(:filter_exp)
+        condition |= ["job_id LIKE '#{opts[:filter_exp]}%'"] if opts.has_key?(:filter_exp)
         query = "SELECT job_id FROM jobs WHERE #{condition.join(' AND ')}"
         query = "#{query} ORDER BY update_id DESC"
         if opts.has_key?(:limit)

--- a/lib/patriot/job_store/rdb_job_store.rb
+++ b/lib/patriot/job_store/rdb_job_store.rb
@@ -401,7 +401,7 @@ END_OB_QUERY
       def find_jobs_by_state(state, opts = {})
         raise "OFFSET is set WITHOUT LIMIT" if opts.has_key?(:offset) && !opts.has_key?(:limit)
         condition = ["state = #{state}", "id != #{@initiator_id}"]
-        condition |= ["job_id LIKE '#{opts[:filter_exp]}'"] if opts.has_key?(:filter_exp)
+        condition |= ["job_id LIKE '%#{opts[:filter_exp]}%'"] if opts.has_key?(:filter_exp)
         query = "SELECT job_id FROM jobs WHERE #{condition.join(' AND ')}"
         query = "#{query} ORDER BY update_id DESC"
         if opts.has_key?(:limit)


### PR DESCRIPTION
We have to use '%'in web console  when searching jobs.

![screenshot from 2017-06-11 15-52-07](https://user-images.githubusercontent.com/795197/27009032-f2c06fce-4ebd-11e7-9426-e01d084e77fc.png)

We are supposed to search job_id without '%' in web console. So I fixed query condition.

![screenshot from 2017-06-11 15-58-18](https://user-images.githubusercontent.com/795197/27009103-7f6ce982-4ec0-11e7-8f50-96086b31812a.png)

