### PR TITLE
Add plugin required for patriot-gcp

### DIFF
--- a/plugins/patriot-gcp/patriot-gcp.gemspec
+++ b/plugins/patriot-gcp/patriot-gcp.gemspec
@@ -19,5 +19,6 @@ Gem::Specification.new do |s|
   s.files         = Dir.glob("lib/**/*") | ["init.rb"]
   s.require_paths = ["lib"]
 
+  s.add_dependency 'google-api-client', '~>0.8.7', '<0.9.0'
   s.add_dependency 'patriot-workflow-scheduler', '~>0.7'
 end


### PR DESCRIPTION
google-api-client version is <0.9.0 for version conflicts
of mime-types plugin which is required by google-api-client
and rest-client.