### PR TITLE
Return boolean in postprocessing

### DIFF
--- a/lib/patriot/command/post_processor/base.rb
+++ b/lib/patriot/command/post_processor/base.rb
@@ -32,15 +32,18 @@ module Patriot
 
         def process(cmd, worker, job_ticket)
           case job_ticket.exit_code
-          when Patriot::Command::ExitCode::SUCCEEDED then process_success(cmd, worker, job_ticket)
-          when Patriot::Command::ExitCode::FAILED    then process_failure(cmd, worker, job_ticket)
+          when Patriot::Command::ExitCode::SUCCEEDED then return process_success(cmd, worker, job_ticket)
+          when Patriot::Command::ExitCode::FAILED    then return process_failure(cmd, worker, job_ticket)
           end
+          return true
         end
 
         def process_success(cmd, worker, job_ticket)
+          return true
         end
 
         def process_failure(cmd, worker, job_ticket)
+          return true
         end
 
       end

--- a/lib/patriot/command/post_processor/discard_on_fail.rb
+++ b/lib/patriot/command/post_processor/discard_on_fail.rb
@@ -8,6 +8,7 @@ module Patriot
 
         def process_failure(cmd, worker, job_ticket)
           worker.job_store.set_state(Time.now.to_i, [cmd.job_id], Patriot::JobStore::JobState::DISCARDED)
+          return true
         end
 
       end

--- a/lib/patriot/command/post_processor/http_notification.rb
+++ b/lib/patriot/command/post_processor/http_notification.rb
@@ -29,6 +29,7 @@ module Patriot
           when Patriot::Command::ExitCode::SUCCEEDED then send_callback(job_ticket.job_id, callback_url, "SUCCEEDED")
           when Patriot::Command::ExitCode::FAILED then send_callback(job_ticket.job_id, callback_url, "FAILED")
           end
+          return true
         end
 
         def send_callback(job_id, callback_url, state)

--- a/lib/patriot/command/post_processor/mail_notification.rb
+++ b/lib/patriot/command/post_processor/mail_notification.rb
@@ -24,6 +24,7 @@ module Patriot
           when Patriot::Command::ExitCode::SUCCEEDED then process_success(cmd, worker, job_ticket)
           when Patriot::Command::ExitCode::FAILED    then process_failure(cmd, worker, job_ticket)
           end
+          return true
         end
 
         def process_success(cmd, worker, job_ticket)

--- a/lib/patriot/command/post_processor/retrial.rb
+++ b/lib/patriot/command/post_processor/retrial.rb
@@ -21,7 +21,7 @@ module Patriot
             found = true
             # count first attempt in
             pp.props[COUNT_PROP_KEY] = pp.props[COUNT_PROP_KEY] - 1
-            return if pp.props[COUNT_PROP_KEY] == 0
+            return true if pp.props[COUNT_PROP_KEY] < 1
             cmd.start_datetime = Time.now + pp.props[INTERVAL_PROP_KEY]
           end
           job = cmd.to_job
@@ -30,6 +30,7 @@ module Patriot
           job[Patriot::Command::REQUISITES_ATTR] = current_config[Patriot::Command::REQUISITES_ATTR]
           job[Patriot::Command::STATE_ATTR] = Patriot::JobStore::JobState::WAIT
           worker.job_store.register(Time.now.to_i, [job])
+          return false
         end
 
       end

--- a/lib/patriot/command/post_processor/skip_on_fail.rb
+++ b/lib/patriot/command/post_processor/skip_on_fail.rb
@@ -8,6 +8,7 @@ module Patriot
 
         def process_failure(cmd, worker, job_ticket)
           worker.job_store.set_state(Time.now.to_i, [cmd.job_id], Patriot::JobStore::JobState::SUCCEEDED)
+          return true
         end
 
       end

--- a/lib/patriot/worker/base.rb
+++ b/lib/patriot/worker/base.rb
@@ -85,10 +85,15 @@ module Patriot
             @logger.error job_store_error
           end
           unless command.post_processors.nil?
+            continue_post_processing = true
             command.post_processors.each do |pp|
               begin
-                @logger.info "executing post process by #{pp}"
-                pp.process(command, self, job_ticket)
+                if continue_post_processing
+                  @logger.info "executing post process by #{pp}"
+                  continue_post_processing = continue_post_processing && pp.process(command, self, job_ticket)
+                else
+                  @logger.info "skipping post process by #{pp}"
+                end
               rescue Exception => post_process_error
                 @logger.error "post process by #{pp} failed"
                 @logger.error post_process_error

--- a/spec/patriot/tool/patriot_commands/register_spec.rb
+++ b/spec/patriot/tool/patriot_commands/register_spec.rb
@@ -30,7 +30,6 @@ describe Patriot::Tool::PatriotCommands::Register do
       expect{Patriot::Tool::PatriotCommand.start(args)}.not_to raise_error
       expect(@job_store.get("sh_echo_2013-01-01")[:state]).to eq Patriot::JobStore::JobState::WAIT
       expect(@job_store.get("sh_echo_2013-01-01")[:priority]).to eq Patriot::JobStore::DEFAULT_PRIORITY
-      expect(@job_store.get("sh_echo_2013-01-01").update_id).to be_between(Time.now.to_i - 60, Time.now.to_i)
     end
 
     it "can debug pbc" do

--- a/spec/patriot/worker/servlet/job_api_servlet_spec.rb
+++ b/spec/patriot/worker/servlet/job_api_servlet_spec.rb
@@ -47,11 +47,12 @@ describe Patriot::Worker::Servlet::JobAPIServlet do
     it "should get stats" do
       expect(JSON.parse(@client["/stats"].get()
       )).to match_array([
-        [Patriot::JobStore::JobState::INIT.to_s,    0],
-        [Patriot::JobStore::JobState::WAIT.to_s,    2],
-        [Patriot::JobStore::JobState::RUNNING.to_s, 1],
-        [Patriot::JobStore::JobState::SUSPEND.to_s, 0],
-        [Patriot::JobStore::JobState::FAILED.to_s,  1]
+        [Patriot::JobStore::JobState::INIT.to_s,      0],
+        [Patriot::JobStore::JobState::DISCARDED.to_s, 0],
+        [Patriot::JobStore::JobState::WAIT.to_s,      2],
+        [Patriot::JobStore::JobState::RUNNING.to_s,   1],
+        [Patriot::JobStore::JobState::SUSPEND.to_s,   0],
+        [Patriot::JobStore::JobState::FAILED.to_s,    1]
       ])
     end
 


### PR DESCRIPTION
I let postprocessors return a boolean to decide whether to continue following post-processors or not. It helps Retrial PostProcessor terminate following post-processors when its counter is big enough to retry, otherwise it doesn't retry and pass to the following.
This implementation implicitly expects developers to order post-processors correctly, i.e. Retrial PostProcessor usually comes first.

Suggestions around this implementation would be appreciated.