### PR TITLE
Return true when MailNotification has nothing to do

### DIFF
--- a/lib/patriot/command/post_processor/mail_notification.rb
+++ b/lib/patriot/command/post_processor/mail_notification.rb
@@ -19,7 +19,7 @@ module Patriot
           on = [on] unless on.is_a?(Array)
           on = on.map{|o| Patriot::Command::ExitCode.value_of(o)}
           exit_code = job_ticket.exit_code
-          return unless on.include?(exit_code)
+          return true unless on.include?(exit_code)
           case exit_code
           when Patriot::Command::ExitCode::SUCCEEDED then process_success(cmd, worker, job_ticket)
           when Patriot::Command::ExitCode::FAILED    then process_failure(cmd, worker, job_ticket)

--- a/lib/patriot/version.rb
+++ b/lib/patriot/version.rb
@@ -1,3 +1,3 @@
 module Patriot
-  VERSION = "0.8.5"
+  VERSION = "0.8.6.alpha"
 end


### PR DESCRIPTION
Let MailNotification post processor return `true` when a given status doesn't match its condition (in other words, it has nothing to do in it), so that other post processors can work.