### PR TITLE
Upgrade bigquery plugin

### DIFF
--- a/patriot-workflow-scheduler.gemspec
+++ b/patriot-workflow-scheduler.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new "patriot-workflow-scheduler", Patriot::VERSION do |s|
   s.add_dependency 'json', '~>1.8'
   s.add_dependency 'inifile', '~>2.0'
   s.add_dependency 'thor', '~>0.18'
-  s.add_dependency 'rest-client', '~>1.6'
+  s.add_dependency 'rest-client', '~>2.0'
   s.add_dependency 'sinatra', '~>1.4'
   s.add_dependency 'sinatra-contrib', '~>1.4'
   s.add_dependency 'mail', '~>2.6'


### PR DESCRIPTION
- 認証方式の変更により、各BigQueryアカウントで新方式の認証ファイルを取得し、セットする必要があります。

- rest-clientのバージョンを上げる必要があるため、patriot-workflow-schedulerのバージョンを上げ、次期バージョン以上を指定しています。
```
version.rb
  VERSION = "0.8.7"

patriot-gcp.gemspec
  s.add_dependency 'patriot-workflow-scheduler', '>=0.8.7'
```

- 古いgemを削除する必要があります。
```
$ gem uninstall rest-client -v1.6.x
$ gem uninstall mime-types -v1.16.x
```
