### PR TITLE
Fix http_notification to pass tests

### DIFF
--- a/lib/patriot/command/post_processor/http_notification.rb
+++ b/lib/patriot/command/post_processor/http_notification.rb
@@ -52,7 +52,10 @@ module Patriot
 
         def valid_url?(url)
           begin
-             URI.parse(url)
+            uri = URI.parse(url)
+            if uri.scheme != 'http' && uri.scheme != 'https'
+              return false
+            end
           rescue URI::InvalidURIError
             return false
           end


### PR DESCRIPTION
tests failed because the result of URI.parse() was changed.

When executing `URI.parse("http://invalid_url")`,
ruby 2.0.0-p648 raises an error, but
ruby 2.3.1-p112 does not raise an error.