### PR TITLE
Upgrade bq plugin

### DIFF
--- a/plugins/patriot-gcp/README.md
+++ b/plugins/patriot-gcp/README.md
@@ -31,9 +31,7 @@ An ini file for this plugin should have the following directives:
 
 ```
 [gcp]
-service_account = <your service account email address>
-private_key = <the location of your p12 key file>
-key_pass = <the key phrase for the private key>
+bigquery_keyfile = <path to json credential file>
 ```
 
 

--- a/plugins/patriot-gcp/README.md
+++ b/plugins/patriot-gcp/README.md
@@ -11,18 +11,17 @@ Implemented Commands
 
 This command enables you to upload data into BigQuery.
 
-
-Option Name | Description
------------ | ------------
-inifile | Indicate the location of the ini file. Assumed format is described below.
-project_id | Set the name of the project id to use.
-dataset | Set the name of the dataset you want to upload data into.
-table | Set the name of the table under the dataset. If the table doesn't exist, it will be created along with the schema you indicate.
-schema | Set the schema which generated data would have.
-input_file | Indicate the location of the file you want to upload.
-name_suffix | Set a name suffix for job_id if needed.
-options | Set BigQuery's load options if needed. These options are set under "configuration.load". For official information, see https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.load
-polling_interval | Set polling interval(min) if needed. Default is 60 mins. If a registered job doesn't finish within the specified polling time, you should check if the job would succeed later on. Its job_id would be written in the log file.
+Option Name | Required | Description
+----------- | :------: | ------------
+inifile | yes | Indicate the location of the ini file. Assumed format is described below.
+project_id | yes | Set the name of the project id to use.
+dataset | yes | Set the name of the dataset you want to upload data into.
+table | yes | Set the name of the table under the dataset. If the table doesn't exist, it will be created along with the schema you indicate.
+schema | | Set the schema which generated data would have.
+input_file | | Indicate the location of the file you want to upload.
+name_suffix | | Set a name suffix for job_id if needed.
+options | | Set BigQuery's load options if needed. These options are set under "configuration.load". For official information, see https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.load
+polling_interval | | Set polling interval(min) if needed. Default is 60 mins. If a registered job doesn't finish within the specified polling time, you should check if the job would succeed later on. Its job_id would be written in the log file.
 
 
 #### inifile
@@ -62,3 +61,62 @@ load_to_bigquery {
           'allowLargeResults' => true
 }
 ```
+
+---
+
+### bq
+
+This command enables you to upload data into BigQuery.
+
+
+Option Name | Required | Description
+----------- | :------: | ------------
+inifile | yes | Indicate the location of the ini file. Assumed format is described below.
+project_id | yes | Set the name of the project id to use.
+name_suffix | yes | Set job name suffix. To set only _date_ is not allowed to avoid job name duplicate.
+statement | yes | Set SQL statement to execute.
+
+
+#### inifile
+
+An ini file for this plugin should have the following directives:
+
+```
+[gcp]
+bigquery_keyfile = <path to json credential file>
+```
+
+
+#### Example
+
+You can use `bq` command in your PBC file like the following.
+
+```
+bq {
+  input_file "/tmp/data_#{_date_}.tsv"
+  inifile '/home/foo/.gcp.ini'
+  name_suffix "insert_some_data_#{_date_}"
+  statement "INSERT INTO `dataset1.table1` (column1) SELECT dt FROM `dataset2.table2` WHERE dt = '2018-05-21'"
+}
+```
+
+#### statement examples
+
+```
+# insert fixed values
+statement "INSERT INTO `dataset1.table1` (column1) VALUES ('A')"
+
+# insert values
+statement "INSERT INTO `dataset1.table1` (column1) SELECT dt FROM `dataset2.table2` WHERE dt = '2018-05-21'"
+
+# insert values from partitioned table
+statement "INSERT INTO `dataset1.table1` (column1) SELECT dt FROM `dataset2.partitioned_table1` WHERE _PARTITIONTIME = '2018-05-21'"
+
+# insert values from partitioned table to partitioned table
+statement "INSERT INTO `dataset1.partitioned_table1` (_PARTITIONTIME, dt) SELECT _PARTITIONTIME, dt FROM `dataset2.partitioned_table2` WHERE _PARTITIONTIME = '2018-05-21'"
+
+# delete from partitioned table
+statement "DELETE FROM `dataset1.partitioned_table1` WHERE _PARTITIONTIME = '2018-05-21'"
+```
+
+* It is not allowed to use decoration characters like "$". Please set `_PARTITIONTIME` to use partitioned table.

--- a/plugins/patriot-gcp/lib/patriot_gcp/command.rb
+++ b/plugins/patriot-gcp/lib/patriot_gcp/command.rb
@@ -1,1 +1,2 @@
 require 'patriot_gcp/command/load_to_bigquery'
+require 'patriot_gcp/command/bq'

--- a/plugins/patriot-gcp/lib/patriot_gcp/command/bq.rb
+++ b/plugins/patriot-gcp/lib/patriot_gcp/command/bq.rb
@@ -1,0 +1,47 @@
+module PatriotGCP
+  module Command
+    class BQCommand < Patriot::Command::Base
+      declare_command_name :bq
+      include PatriotGCP::Ext::BigQuery
+
+      command_attr :inifile, :project_id, :statement, :name_suffix
+      validate_existence :inifile, :project_id, :statement, :name_suffix
+
+      class BigQueryException < Exception; end
+      class GoogleCloudPlatformException < Exception; end
+
+      def job_id
+        "#{command_name}_#{@project_id}_#{@name_suffix}"
+      end
+
+      # @see Patriot::Command::Base#configure
+      def configure
+        if @name_suffix == _date_
+          raise ArgumentError, 'To set _date_ only is not allowed here to avoid job name duplication.'
+        end
+        @statement = eval_attr(@statement)
+        self
+      end
+
+      def execute
+        @logger.info "start bq"
+
+        ini = IniFile.load(@inifile)
+        if ini.nil?
+          raise Exception, "inifile not found"
+        end
+
+        bigquery_keyfile  = ini["gcp"]["bigquery_keyfile"]
+
+        stat_info = bq(
+          bigquery_keyfile,
+          @project_id,
+          @statement
+        )
+
+        @logger.info "statement execution succeeded: #{stat_info}"
+        @logger.info "end bq"
+      end
+    end
+  end
+end

--- a/plugins/patriot-gcp/lib/patriot_gcp/command/load_to_bigquery.rb
+++ b/plugins/patriot-gcp/lib/patriot_gcp/command/load_to_bigquery.rb
@@ -28,9 +28,7 @@ module PatriotGCP
           raise Exception, "inifile not found"
         end
 
-        service_account  = ini["gcp"]["service_account"]
-        private_key      = ini["gcp"]["private_key"]
-        key_pass         = ini["gcp"]["key_pass"]
+        bigquery_keyfile  = ini["gcp"]["bigquery_keyfile"]
 
         unless File.exist?(@input_file)
           raise Exception, "The given file doesn't exist."
@@ -41,15 +39,9 @@ module PatriotGCP
           return
         end
 
-        if service_account.nil? or private_key.nil?
-          raise GoogleCloudPlatformException, "configuration for GCP is not enough."
-        end
-
         @logger.info "start uploading"
         stat_info = bq_load(@input_file,
-                            private_key,
-                            key_pass,
-                            service_account,
+                            bigquery_keyfile,
                             @project_id,
                             @dataset,
                             @table,

--- a/plugins/patriot-gcp/lib/patriot_gcp/ext/bigquery.rb
+++ b/plugins/patriot-gcp/lib/patriot_gcp/ext/bigquery.rb
@@ -82,6 +82,24 @@ module PatriotGCP
         end
       end
 
+      def bq(bigquery_keyfile, project_id, statement)
+        ENV['BIGQUERY_KEYFILE'] = bigquery_keyfile
+
+        bigquery = Google::Cloud::Bigquery.new(
+          project: project_id,
+          retries: 3
+        )
+
+        job = bigquery.query_job statement
+
+        job.wait_until_done!
+
+        if job.failed?
+          raise BigQueryException, "statement execution failed: #{job.errors}"
+        else
+          return job.statistics
+        end
+      end
     end
   end
 end

--- a/plugins/patriot-gcp/lib/patriot_gcp/ext/bigquery.rb
+++ b/plugins/patriot-gcp/lib/patriot_gcp/ext/bigquery.rb
@@ -69,6 +69,7 @@ module PatriotGCP
           skip_leading: options['skipLeadingRows'] || nil,
           write: options['writeDisposition'] || nil,
           delimiter: options['fieldDelimiter'] || nil,
+          null_marker: options['nullMarker'] || nil,
         )
 
         job.wait_until_done!

--- a/plugins/patriot-gcp/lib/patriot_gcp/ext/bigquery.rb
+++ b/plugins/patriot-gcp/lib/patriot_gcp/ext/bigquery.rb
@@ -65,6 +65,7 @@ module PatriotGCP
         job = dataset.load_job(
           table_id,
           filename,
+          format: options['format'] || nil,
           quote: options['quote'] || nil,
           skip_leading: options['skipLeadingRows'] || nil,
           write: options['writeDisposition'] || nil,

--- a/plugins/patriot-gcp/lib/patriot_gcp/version.rb
+++ b/plugins/patriot-gcp/lib/patriot_gcp/version.rb
@@ -1,4 +1,4 @@
 class VERSION
-  VERSION = "0.1.2.alpha"
+  VERSION = "0.2.0.alpha"
   PROJECT_NAME = "patriot-gcp"
 end

--- a/plugins/patriot-gcp/patriot-gcp.gemspec
+++ b/plugins/patriot-gcp/patriot-gcp.gemspec
@@ -6,7 +6,7 @@ require 'patriot_gcp/version'
 Gem::Specification.new do |s|
   s.name        = VERSION::PROJECT_NAME
   s.version     = VERSION::VERSION
-  s.licenses    = ['Apache License, Version 2.0']
+  s.licenses    = ['Apache-2.0']
   s.authors     = ["Hitoshi Tsuda"]
   s.email       = ["tsuda_hitoshi@cyberagent.co.jp"]
   s.homepage    = "https://github.com/CyberAgent/patriot-workflow-scheduler/tree/master/plugins/patriot-gcp"
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
   s.files         = Dir.glob("lib/**/*") | ["init.rb"]
   s.require_paths = ["lib"]
 
-  s.add_dependency 'google-api-client', '~>0.8.7', '<0.9.0'
-  s.add_dependency 'patriot-workflow-scheduler', '~>0.7'
+  s.add_dependency 'google-cloud-bigquery', '~>1.3'
+  s.add_dependency 'patriot-workflow-scheduler', '>=0.8.7'
 end

--- a/plugins/patriot-gcp/spec/patriot_gcp/command/bq_spec.rb
+++ b/plugins/patriot-gcp/spec/patriot_gcp/command/bq_spec.rb
@@ -1,0 +1,89 @@
+require "init_test"
+require 'erb'
+include Patriot::Command::Parser
+
+describe PatriotGCP::Command::BQCommand do
+  before :all do
+    @target_datetime = DateTime.new(2011,12,12)
+    @config = config_for_test
+  end
+
+  describe 'job_id' do
+    it 'should get job_id' do
+      cmd = new_command(PatriotGCP::Command::BQCommand) do
+        inifile path_to_test_config('test-bigquery.ini')
+        project_id 'test-project-id'
+        name_suffix "job-id-test_#{_date_}"
+        statement 'statement for test'
+      end
+      cmd = cmd.build[0]
+
+      expect(cmd.job_id).to eq('bq_test-project-id_job-id-test_2011-12-12')
+    end
+
+    it 'should raise ArgumentError when only _date_ is set to name_suffix' do
+      cmd = new_command(PatriotGCP::Command::BQCommand) do
+        inifile path_to_test_config('test-bigquery.ini')
+        project_id 'test-project-id'
+        name_suffix _date_
+        statement 'statement for test'
+      end
+
+      expect { cmd.build[0] }.to raise_error(
+        ArgumentError,
+        'To set _date_ only is not allowed here to avoid job name duplication.'
+      )
+    end
+  end
+
+  describe 'configure' do
+    it 'should raise an error when inifile is not set' do
+      cmd = new_command(PatriotGCP::Command::BQCommand) do
+        project_id 'test-project-id'
+        name_suffix "job-id-test_#{_date_}"
+        statement 'statement for test'
+      end
+      expect { cmd.build[0] }.to raise_error(
+        RuntimeError,
+        'validation error : inifile= (PatriotGCP::Command::BQCommand)'
+      )
+    end
+
+    it 'should raise an error when project_id is not set' do
+      cmd = new_command(PatriotGCP::Command::BQCommand) do
+        inifile path_to_test_config('test-bigquery.ini')
+        name_suffix "job-id-test_#{_date_}"
+        statement 'statement for test'
+      end
+      expect { cmd.build[0] }.to raise_error(
+        RuntimeError,
+        'validation error : project_id= (PatriotGCP::Command::BQCommand)'
+      )
+    end
+  end
+
+  it "should work" do
+    allow_any_instance_of(PatriotGCP::Ext::BigQuery).to receive(:bq)
+    cmd = new_command(PatriotGCP::Command::BQCommand) do
+      inifile path_to_test_config('test-bigquery.ini')
+      project_id 'test-project-id'
+      name_suffix "job-id-test_#{_date_}"
+      statement 'statement for test'
+    end
+    cmd = cmd.build[0]
+    cmd.execute
+  end
+
+  it "should raise an error when the ini file doesn't exist" do
+    allow_any_instance_of(PatriotGCP::Ext::BigQuery).to receive(:bq)
+    cmd = new_command(PatriotGCP::Command::BQCommand) do
+      inifile 'UNEXIST FILE'
+      project_id 'test-project-id'
+      name_suffix "job-id-test_#{_date_}"
+      statement 'statement for test'
+    end
+    cmd = cmd.build[0]
+
+    expect { cmd.execute }.to raise_error(Exception, 'inifile not found')
+  end
+end

--- a/plugins/patriot-gcp/spec/patriot_gcp/ext/bigquery_spec.rb
+++ b/plugins/patriot-gcp/spec/patriot_gcp/ext/bigquery_spec.rb
@@ -4,247 +4,159 @@ include PatriotGCP::Ext::BigQuery
 
 
 describe PatriotGCP::Ext::BigQuery do
-
-  before :each do 
-    allow(Google::APIClient::KeyUtils).to receive(:load_from_pkcs12).with('/path/to/keyfile', 'key_pass').and_return('test-key')
-    allow(Signet::OAuth2::Client).to receive(:new).and_return(double('auth-client-mock', {"fetch_access_token!" => true}))
-    @config = config_for_test
-  end
-
-
   it "should load data to bigquery" do
-    api_client_mock = double('api-client-mock')
-    allow(api_client_mock).to receive(:discovered_api).with('bigquery', 'v2'){
-        double(nil,
-               {:jobs => double(nil,
-                                {:get => "GET",
-                                 :insert => "INSERT"})})
-    }
-    allow(api_client_mock).to receive(:execute).with(hash_including(:api_method => 'INSERT',
-                                                                    :parameters => {
-                                                                        'projectId' => 'test-project',
-                                                                        'uploadType' => 'multipart'
-                                                                    })){
-        double(nil,
-               {:response => double(nil,
-                                    {:body => '{"jobReference": {"jobId": "job_id01"}}'})})
-    }
-    allow(api_client_mock).to receive(:execute).with(hash_including(:api_method => 'GET',
-                                                                    :parameters => {
-                                                                        'projectId' => 'test-project',
-                                                                        'jobId' => "job_id01"
-                                                                    })){
-        double(nil,
-               {:response => double(nil,
-                                    {:body => '{"status": {"state": "DONE"},
-                                                "statistics": {"insertline": 1}}'})})
-    }
+    bigquery_mock = double('Google::Cloud::Bigquery mock')
+    dataset_mock  = double('Google::Cloud::Bigquery dataset mock')
+    table_mock    = double('Google::Cloud::Bigquery table mock')
+    job_mock      = double('Google::Cloud::Bigquery job mock')
 
-    allow(Google::APIClient).to receive(:new).and_return(api_client_mock)
-    expect(api_client_mock).to receive(:execute).with(hash_including(:api_method => "INSERT")).once
-    expect(api_client_mock).to receive(:execute).with(hash_including(:api_method => "GET")).once
-    bq_load(File.join(SAMPLE_DIR, "hive_result.txt"),
-            '/path/to/keyfile',
-            'key_pass',
-            'test-account@developer.gserviceaccount.com',
-            'test-project',
-            'test-dataset',
-            'test-table',
-            'field1',
-            options={'fieldDelimiter' => '\t',
-                     'writeDisposition' => 'WRITE_APPEND',
-                     'allowLargeResults' => true})
+    allow(Google::Cloud::Bigquery).to receive(:new).and_return(bigquery_mock)
+    allow(bigquery_mock).to receive(:dataset).and_return(dataset_mock)
+    allow(dataset_mock).to receive(:table).and_return(table_mock)
+    allow(dataset_mock).to receive(:create_table)
+    allow(dataset_mock).to receive(:load_job).and_return(job_mock)
+    allow(table_mock).to receive(:nil?).and_return(true)
+    allow(job_mock).to receive(:wait_until_done!)
+    allow(job_mock).to receive(:failed?).and_return(false)
+    allow(job_mock).to receive(:statistics)
+
+    bq_load(
+      File.join(SAMPLE_DIR, "hive_result.txt"),
+      '/path/to/bigquery_keyfile',
+      'test-project',
+      'test-dataset',
+      'test-table',
+      'field1',
+      {
+        'fieldDelimiter' => '\t',
+        'writeDisposition' => 'WRITE_APPEND'
+      }
+    )
+
+    expect(ENV.fetch('BIGQUERY_KEYFILE')).to eq('/path/to/bigquery_keyfile')
+    expect(Google::Cloud::Bigquery).to have_received(:new).with(
+      project: 'test-project',
+      retries: 3,
+      timeout: 3600
+    ).once
+    expect(bigquery_mock).to have_received(:dataset).with('test-dataset').once
+    expect(dataset_mock).to have_received(:load_job).with(
+      'test-table',
+      File.join(SAMPLE_DIR, "hive_result.txt"),
+      format: nil,
+      quote: nil,
+      skip_leading: nil,
+      write: 'WRITE_APPEND',
+      delimiter: '\t',
+      null_marker: nil
+    ).once
+    expect(job_mock).to have_received(:wait_until_done!).once
+    expect(job_mock).to have_received(:failed?).once
+    expect(job_mock).to have_received(:statistics).once
   end
 
+  it "should set time" do
+    bigquery_mock = double('Google::Cloud::Bigquery mock')
+    dataset_mock  = double('Google::Cloud::Bigquery dataset mock')
+    table_mock    = double('Google::Cloud::Bigquery table mock')
+    job_mock      = double('Google::Cloud::Bigquery job mock')
+
+    allow(Google::Cloud::Bigquery).to receive(:new).and_return(bigquery_mock)
+    allow(bigquery_mock).to receive(:dataset).and_return(dataset_mock)
+    allow(dataset_mock).to receive(:table).and_return(table_mock)
+    allow(dataset_mock).to receive(:create_table)
+    allow(dataset_mock).to receive(:load_job).and_return(job_mock)
+    allow(job_mock).to receive(:wait_until_done!)
+    allow(job_mock).to receive(:failed?).and_return(false)
+    allow(job_mock).to receive(:statistics)
+
+    bq_load(
+      File.join(SAMPLE_DIR, "hive_result.txt"),
+      '/path/to/bigquery_keyfile',
+      'test-project',
+      'test-dataset',
+      'test-table',
+      'field1',
+      options = {
+        'fieldDelimiter' => '\t',
+        'writeDisposition' => 'WRITE_APPEND'
+      },
+      polling_interval = 1
+    )
+
+    expect(Google::Cloud::Bigquery).to have_received(:new)
+      .with(
+      project: 'test-project',
+      retries: 3,
+      timeout: 60
+    ).once
+    expect(Google::Cloud::Bigquery).to have_received(:new)
+    expect(job_mock).to have_received(:wait_until_done!).once
+    expect(job_mock).to have_received(:failed?).once
+    expect(job_mock).to have_received(:statistics).once
+  end
 
   it "raises BigQueryException when not finishing in time" do
-    api_client_mock = double('api-client-mock')
-    allow(api_client_mock).to receive(:discovered_api).with('bigquery', 'v2'){
-        double(nil,
-               {:jobs => double(nil,
-                                {:get => "GET",
-                                 :insert => "INSERT"})})
-    }
-    allow(api_client_mock).to receive(:execute).with(hash_including(:api_method => 'INSERT',
-                                                                    :parameters => {
-                                                                        'projectId' => 'test-project',
-                                                                        'uploadType' => 'multipart'
-                                                                    })){
-        double(nil,
-               {:response => double(nil,
-                                    {:body => '{"jobReference": {"jobId": "job_id01"}}'})})
-    }
+    bigquery_mock = double('Google::Cloud::Bigquery mock')
+    dataset_mock  = double('Google::Cloud::Bigquery dataset mock')
+    table_mock    = double('Google::Cloud::Bigquery table mock')
 
-    allow(Google::APIClient).to receive(:new).and_return(api_client_mock)
-    expect(api_client_mock).to receive(:execute).with(hash_including(:api_method => "INSERT")).once
+    allow(Google::Cloud::Bigquery).to receive(:new).and_return(bigquery_mock)
+    allow(bigquery_mock).to receive(:dataset).and_return(dataset_mock)
+
+    # execution expired (Google::Cloud::Error)
+    allow(dataset_mock).to receive(:table).and_return(table_mock)
+    allow(dataset_mock).to receive(:create_table)
+    allow(dataset_mock).to receive(:load_job).and_raise(Google::Cloud::Error)
+
     expect {
-        bq_load(File.join(SAMPLE_DIR, "hive_result.txt"),
-                '/path/to/keyfile',
-                'key_pass',
-                'test-account@developer.gserviceaccount.com',
-                'test-project',
-                'test-dataset',
-                'test-table',
-                'field1',
-                options={'fieldDelimiter' => '\t',
-                         'writeDisposition' => 'WRITE_APPEND',
-                         'allowLargeResults' => true},
-                polling_interval=0)
-    }.to raise_error(BigQueryException)
-
-  end
-
-
-  it "raises BigQueryException when getting error from api" do
-    api_client_mock = double('api-client-mock')
-    allow(api_client_mock).to receive(:discovered_api).with(
-      'bigquery', 'v2'
-    ){
-      double(
-        nil, 
-        {:jobs => double(
-          nil,
-          {:get => "GET", :insert => "INSERT"}
-        )}
-      )
-    }
-
-    allow(api_client_mock).to receive(:execute).with(
-      hash_including(
-        :api_method => 'INSERT',
-        :parameters => {
-          'projectId' => 'test-project',
-          'uploadType' => 'multipart'
+      bq_load(
+        File.join(SAMPLE_DIR, "hive_result.txt"),
+        '/path/to/bigquery_keyfile',
+        'test-project',
+        'test-dataset',
+        'test-table',
+        'field1',
+        options = {
+          'fieldDelimiter' => '\t',
+          'writeDisposition' => 'WRITE_APPEND'
         }
       )
-    ){
-      double(
-        nil,
-        {:response => double(
-          nil, 
-          {
-            :body => '{"status": {
-              "state": "DONE"
-              "errorResult"=>{
-                "reason"=>"invalid",
-                "message"=>"Too many errors encountered. Limit is: 0."
-              },
-              "errors"=>[
-                {
-                  "reason"=>"invalid",
-                  "location"=>"File: 0 / Line:100 / Field:6",
-                  "message"=>"Invalid argument: 1,234.0"
-                },
-                {
-                  "reason"=>"invalid",
-                  "message"=>"Too many errors encountered. Limit is: 0."
-                }
-              ]
-            }}'
-          }
-        )}
+    }.to raise_error(Google::Cloud::Error)
+  end
+
+  it "raises BigQueryException when getting error from api" do
+    bigquery_mock = double('Google::Cloud::Bigquery mock')
+    dataset_mock  = double('Google::Cloud::Bigquery dataset mock')
+    table_mock    = double('Google::Cloud::Bigquery table mock')
+    job_mock      = double('Google::Cloud::Bigquery job mock')
+
+    allow(Google::Cloud::Bigquery).to receive(:new).and_return(bigquery_mock)
+    allow(bigquery_mock).to receive(:dataset).and_return(dataset_mock)
+    allow(dataset_mock).to receive(:table).and_return(table_mock)
+    allow(dataset_mock).to receive(:create_table)
+    allow(dataset_mock).to receive(:load_job).and_return(job_mock)
+    allow(job_mock).to receive(:wait_until_done!)
+    allow(job_mock).to receive(:failed?).and_return(true)
+    allow(job_mock).to receive(:errors)
+
+    expect {
+      bq_load(
+        File.join(SAMPLE_DIR, "hive_result.txt"),
+        '/path/to/bigquery_keyfile',
+        'test-project',
+        'test-dataset',
+        'test-table',
+        'field1',
+        options = {
+          'fieldDelimiter' => '\t',
+          'writeDisposition' => 'WRITE_APPEND'
+        }
       )
-    }
-      
-    allow(Google::APIClient).to receive(:new).and_return(api_client_mock)
-    expect(api_client_mock).to receive(:execute).with(hash_including(:api_method => "INSERT")).once
-    expect(api_client_mock).to receive(:execute).with(hash_including(:api_method => "GET")).never
-    expect {
-      bq_load(File.join(SAMPLE_DIR, "hive_result.txt"),
-              '/path/to/keyfile',
-              'key_pass',
-              'test-account@developer.gserviceaccount.com',
-              'test-project',
-              'test-dataset',
-              'test-table',
-              'field1',
-              options={'fieldDelimiter' => '\t',
-                       'writeDisposition' => 'WRITE_APPEND',
-                       'allowLargeResults' => true})
     }.to raise_error(BigQueryException)
-  end
 
-
-  it "loads data to bigquery but fails to register a job" do
-    api_client_mock = double('api-client-mock')
-    allow(api_client_mock).to receive(:discovered_api).with('bigquery', 'v2'){
-        double(nil,
-               {:jobs => double(nil,
-                                {:get => "GET",
-                                 :insert => "INSERT"})})
-    }
-
-    allow(api_client_mock).to receive(:execute).with(hash_including(:api_method => 'INSERT',
-                                                                    :parameters => {
-                                                                        'projectId' => 'test-project',
-                                                                        'uploadType' => 'multipart'
-                                                                    })){
-        double(nil, {:response => double(nil, {:body => '{}'})})  # response doesn't include a job ID
-    }   
-    allow(Google::APIClient).to receive(:new).and_return(api_client_mock)
-    expect(api_client_mock).to receive(:execute).with(hash_including(:api_method => "INSERT")).once
-    expect(api_client_mock).to receive(:execute).with(hash_including(:api_method => "GET")).never
-    expect {
-      bq_load(File.join(SAMPLE_DIR, "hive_result.txt"),
-              '/path/to/keyfile',
-              'key_pass',
-              'test-account@developer.gserviceaccount.com',
-              'test-project',
-              'test-dataset',
-              'test-table',
-              'field1',
-              options={'fieldDelimiter' => '\t',
-                       'writeDisposition' => 'WRITE_APPEND',
-                       'allowLargeResults' => true})
-    }.to raise_error(BigQueryException)
-  end
-
-
-  it "loads data to bigquery but the job fails" do
-    api_client_mock = double('api-client-mock')
-    allow(api_client_mock).to receive(:discovered_api).with('bigquery', 'v2'){
-        double(nil,
-               {:jobs => double(nil,
-                                {:get => "GET",
-                                 :insert => "INSERT"})})
-    }
-    allow(api_client_mock).to receive(:execute).with(hash_including(:api_method => 'INSERT',
-                                                                    :parameters => {
-                                                                        'projectId' => 'test-project',
-                                                                        'uploadType' => 'multipart'
-                                                                    })){
-        double(nil,
-               {:response => double(nil,
-                                    {:body => '{"jobReference": {"jobId": "job_id01"}}'})})
-    }
-
-    # response contains errors
-    allow(api_client_mock).to receive(:execute).with(hash_including(:api_method => 'GET',
-                                                                    :parameters => {
-                                                                        'projectId' => 'test-project',
-                                                                        'jobId' => "job_id01"
-                                                                    })){
-        double(nil,
-               {:response => double(nil,
-                                    {:body => '{"status": {"state": "DONE", "errors": ["test error"]},
-                                                "statistics": {"insertline": 1}}'})})
-    }
-
-    allow(Google::APIClient).to receive(:new).and_return(api_client_mock)
-    expect(api_client_mock).to receive(:execute).with(hash_including(:api_method => "INSERT")).once
-    expect(api_client_mock).to receive(:execute).with(hash_including(:api_method => "GET")).once
-    expect {
-      bq_load(File.join(SAMPLE_DIR, "hive_result.txt"),
-              '/path/to/keyfile',
-              'key_pass',
-              'test-account@developer.gserviceaccount.com',
-              'test-project',
-              'test-dataset',
-              'test-table',
-              'field1',
-              options={'fieldDelimiter' => '\t',
-                       'writeDisposition' => 'WRITE_APPEND',
-                       'allowLargeResults' => true})
-    }.to raise_error(BigQueryException)
+    expect(job_mock).to have_received(:wait_until_done!).once
+    expect(job_mock).to have_received(:failed?).once
+    expect(job_mock).to have_received(:errors).once
   end
 end

--- a/plugins/patriot-gcp/spec/patriot_gcp/ext/bigquery_spec.rb
+++ b/plugins/patriot-gcp/spec/patriot_gcp/ext/bigquery_spec.rb
@@ -4,112 +4,73 @@ include PatriotGCP::Ext::BigQuery
 
 
 describe PatriotGCP::Ext::BigQuery do
-  it "should load data to bigquery" do
-    bigquery_mock = double('Google::Cloud::Bigquery mock')
-    dataset_mock  = double('Google::Cloud::Bigquery dataset mock')
-    table_mock    = double('Google::Cloud::Bigquery table mock')
-    job_mock      = double('Google::Cloud::Bigquery job mock')
+  describe "bq_load" do
+    it "should load data to bigquery" do
+      bigquery_mock = double('Google::Cloud::Bigquery mock')
+      dataset_mock  = double('Google::Cloud::Bigquery dataset mock')
+      table_mock    = double('Google::Cloud::Bigquery table mock')
+      job_mock      = double('Google::Cloud::Bigquery job mock')
 
-    allow(Google::Cloud::Bigquery).to receive(:new).and_return(bigquery_mock)
-    allow(bigquery_mock).to receive(:dataset).and_return(dataset_mock)
-    allow(dataset_mock).to receive(:table).and_return(table_mock)
-    allow(dataset_mock).to receive(:create_table)
-    allow(dataset_mock).to receive(:load_job).and_return(job_mock)
-    allow(table_mock).to receive(:nil?).and_return(true)
-    allow(job_mock).to receive(:wait_until_done!)
-    allow(job_mock).to receive(:failed?).and_return(false)
-    allow(job_mock).to receive(:statistics)
+      allow(Google::Cloud::Bigquery).to receive(:new).and_return(bigquery_mock)
+      allow(bigquery_mock).to receive(:dataset).and_return(dataset_mock)
+      allow(dataset_mock).to receive(:table).and_return(table_mock)
+      allow(dataset_mock).to receive(:create_table)
+      allow(dataset_mock).to receive(:load_job).and_return(job_mock)
+      allow(table_mock).to receive(:nil?).and_return(true)
+      allow(job_mock).to receive(:wait_until_done!)
+      allow(job_mock).to receive(:failed?).and_return(false)
+      allow(job_mock).to receive(:statistics)
 
-    bq_load(
-      File.join(SAMPLE_DIR, "hive_result.txt"),
-      '/path/to/bigquery_keyfile',
-      'test-project',
-      'test-dataset',
-      'test-table',
-      'field1',
-      {
-        'fieldDelimiter' => '\t',
-        'writeDisposition' => 'WRITE_APPEND'
-      }
-    )
+      bq_load(
+        File.join(SAMPLE_DIR, "hive_result.txt"),
+        '/path/to/bigquery_keyfile',
+        'test-project',
+        'test-dataset',
+        'test-table',
+        'field1',
+        {
+          'fieldDelimiter' => '\t',
+          'writeDisposition' => 'WRITE_APPEND'
+        }
+      )
 
-    expect(ENV.fetch('BIGQUERY_KEYFILE')).to eq('/path/to/bigquery_keyfile')
-    expect(Google::Cloud::Bigquery).to have_received(:new).with(
-      project: 'test-project',
-      retries: 3,
-      timeout: 3600
-    ).once
-    expect(bigquery_mock).to have_received(:dataset).with('test-dataset').once
-    expect(dataset_mock).to have_received(:load_job).with(
-      'test-table',
-      File.join(SAMPLE_DIR, "hive_result.txt"),
-      format: nil,
-      quote: nil,
-      skip_leading: nil,
-      write: 'WRITE_APPEND',
-      delimiter: '\t',
-      null_marker: nil
-    ).once
-    expect(job_mock).to have_received(:wait_until_done!).once
-    expect(job_mock).to have_received(:failed?).once
-    expect(job_mock).to have_received(:statistics).once
-  end
+      expect(ENV.fetch('BIGQUERY_KEYFILE')).to eq('/path/to/bigquery_keyfile')
+      expect(Google::Cloud::Bigquery).to have_received(:new).with(
+        project: 'test-project',
+        retries: 3,
+        timeout: 3600
+      ).once
+      expect(bigquery_mock).to have_received(:dataset).with('test-dataset').once
+      expect(dataset_mock).to have_received(:load_job).with(
+        'test-table',
+        File.join(SAMPLE_DIR, "hive_result.txt"),
+        format: nil,
+        quote: nil,
+        skip_leading: nil,
+        write: 'WRITE_APPEND',
+        delimiter: '\t',
+        null_marker: nil
+      ).once
+      expect(job_mock).to have_received(:wait_until_done!).once
+      expect(job_mock).to have_received(:failed?).once
+      expect(job_mock).to have_received(:statistics).once
+    end
 
-  it "should set time" do
-    bigquery_mock = double('Google::Cloud::Bigquery mock')
-    dataset_mock  = double('Google::Cloud::Bigquery dataset mock')
-    table_mock    = double('Google::Cloud::Bigquery table mock')
-    job_mock      = double('Google::Cloud::Bigquery job mock')
+    it "should set time" do
+      bigquery_mock = double('Google::Cloud::Bigquery mock')
+      dataset_mock  = double('Google::Cloud::Bigquery dataset mock')
+      table_mock    = double('Google::Cloud::Bigquery table mock')
+      job_mock      = double('Google::Cloud::Bigquery job mock')
 
-    allow(Google::Cloud::Bigquery).to receive(:new).and_return(bigquery_mock)
-    allow(bigquery_mock).to receive(:dataset).and_return(dataset_mock)
-    allow(dataset_mock).to receive(:table).and_return(table_mock)
-    allow(dataset_mock).to receive(:create_table)
-    allow(dataset_mock).to receive(:load_job).and_return(job_mock)
-    allow(job_mock).to receive(:wait_until_done!)
-    allow(job_mock).to receive(:failed?).and_return(false)
-    allow(job_mock).to receive(:statistics)
+      allow(Google::Cloud::Bigquery).to receive(:new).and_return(bigquery_mock)
+      allow(bigquery_mock).to receive(:dataset).and_return(dataset_mock)
+      allow(dataset_mock).to receive(:table).and_return(table_mock)
+      allow(dataset_mock).to receive(:create_table)
+      allow(dataset_mock).to receive(:load_job).and_return(job_mock)
+      allow(job_mock).to receive(:wait_until_done!)
+      allow(job_mock).to receive(:failed?).and_return(false)
+      allow(job_mock).to receive(:statistics)
 
-    bq_load(
-      File.join(SAMPLE_DIR, "hive_result.txt"),
-      '/path/to/bigquery_keyfile',
-      'test-project',
-      'test-dataset',
-      'test-table',
-      'field1',
-      options = {
-        'fieldDelimiter' => '\t',
-        'writeDisposition' => 'WRITE_APPEND'
-      },
-      polling_interval = 1
-    )
-
-    expect(Google::Cloud::Bigquery).to have_received(:new)
-      .with(
-      project: 'test-project',
-      retries: 3,
-      timeout: 60
-    ).once
-    expect(Google::Cloud::Bigquery).to have_received(:new)
-    expect(job_mock).to have_received(:wait_until_done!).once
-    expect(job_mock).to have_received(:failed?).once
-    expect(job_mock).to have_received(:statistics).once
-  end
-
-  it "raises BigQueryException when not finishing in time" do
-    bigquery_mock = double('Google::Cloud::Bigquery mock')
-    dataset_mock  = double('Google::Cloud::Bigquery dataset mock')
-    table_mock    = double('Google::Cloud::Bigquery table mock')
-
-    allow(Google::Cloud::Bigquery).to receive(:new).and_return(bigquery_mock)
-    allow(bigquery_mock).to receive(:dataset).and_return(dataset_mock)
-
-    # execution expired (Google::Cloud::Error)
-    allow(dataset_mock).to receive(:table).and_return(table_mock)
-    allow(dataset_mock).to receive(:create_table)
-    allow(dataset_mock).to receive(:load_job).and_raise(Google::Cloud::Error)
-
-    expect {
       bq_load(
         File.join(SAMPLE_DIR, "hive_result.txt"),
         '/path/to/bigquery_keyfile',
@@ -120,43 +81,147 @@ describe PatriotGCP::Ext::BigQuery do
         options = {
           'fieldDelimiter' => '\t',
           'writeDisposition' => 'WRITE_APPEND'
-        }
+        },
+        polling_interval = 1
       )
-    }.to raise_error(Google::Cloud::Error)
+
+      expect(Google::Cloud::Bigquery).to have_received(:new)
+        .with(
+        project: 'test-project',
+        retries: 3,
+        timeout: 60
+      ).once
+      expect(Google::Cloud::Bigquery).to have_received(:new)
+      expect(job_mock).to have_received(:wait_until_done!).once
+      expect(job_mock).to have_received(:failed?).once
+      expect(job_mock).to have_received(:statistics).once
+    end
+
+    it "raises BigQueryException when not finishing in time" do
+      bigquery_mock = double('Google::Cloud::Bigquery mock')
+      dataset_mock  = double('Google::Cloud::Bigquery dataset mock')
+      table_mock    = double('Google::Cloud::Bigquery table mock')
+
+      allow(Google::Cloud::Bigquery).to receive(:new).and_return(bigquery_mock)
+      allow(bigquery_mock).to receive(:dataset).and_return(dataset_mock)
+
+      # execution expired (Google::Cloud::Error)
+      allow(dataset_mock).to receive(:table).and_return(table_mock)
+      allow(dataset_mock).to receive(:create_table)
+      allow(dataset_mock).to receive(:load_job).and_raise(Google::Cloud::Error)
+
+      expect {
+        bq_load(
+          File.join(SAMPLE_DIR, "hive_result.txt"),
+          '/path/to/bigquery_keyfile',
+          'test-project',
+          'test-dataset',
+          'test-table',
+          'field1',
+          options = {
+            'fieldDelimiter' => '\t',
+            'writeDisposition' => 'WRITE_APPEND'
+          }
+        )
+      }.to raise_error(Google::Cloud::Error)
+    end
+
+    it "raises BigQueryException when getting error from api" do
+      bigquery_mock = double('Google::Cloud::Bigquery mock')
+      dataset_mock  = double('Google::Cloud::Bigquery dataset mock')
+      table_mock    = double('Google::Cloud::Bigquery table mock')
+      job_mock      = double('Google::Cloud::Bigquery job mock')
+
+      allow(Google::Cloud::Bigquery).to receive(:new).and_return(bigquery_mock)
+      allow(bigquery_mock).to receive(:dataset).and_return(dataset_mock)
+      allow(dataset_mock).to receive(:table).and_return(table_mock)
+      allow(dataset_mock).to receive(:create_table)
+      allow(dataset_mock).to receive(:load_job).and_return(job_mock)
+      allow(job_mock).to receive(:wait_until_done!)
+      allow(job_mock).to receive(:failed?).and_return(true)
+      allow(job_mock).to receive(:errors)
+
+      expect {
+        bq_load(
+          File.join(SAMPLE_DIR, "hive_result.txt"),
+          '/path/to/bigquery_keyfile',
+          'test-project',
+          'test-dataset',
+          'test-table',
+          'field1',
+          options = {
+            'fieldDelimiter' => '\t',
+            'writeDisposition' => 'WRITE_APPEND'
+          }
+        )
+      }.to raise_error(BigQueryException)
+
+      expect(job_mock).to have_received(:wait_until_done!).once
+      expect(job_mock).to have_received(:failed?).once
+      expect(job_mock).to have_received(:errors).once
+    end
   end
 
-  it "raises BigQueryException when getting error from api" do
-    bigquery_mock = double('Google::Cloud::Bigquery mock')
-    dataset_mock  = double('Google::Cloud::Bigquery dataset mock')
-    table_mock    = double('Google::Cloud::Bigquery table mock')
-    job_mock      = double('Google::Cloud::Bigquery job mock')
+  describe "bq" do
+    it "should load data to bigquery" do
+      bigquery_mock = double('Google::Cloud::Bigquery mock')
+      job_mock      = double('Google::Cloud::Bigquery job mock')
 
-    allow(Google::Cloud::Bigquery).to receive(:new).and_return(bigquery_mock)
-    allow(bigquery_mock).to receive(:dataset).and_return(dataset_mock)
-    allow(dataset_mock).to receive(:table).and_return(table_mock)
-    allow(dataset_mock).to receive(:create_table)
-    allow(dataset_mock).to receive(:load_job).and_return(job_mock)
-    allow(job_mock).to receive(:wait_until_done!)
-    allow(job_mock).to receive(:failed?).and_return(true)
-    allow(job_mock).to receive(:errors)
+      allow(Google::Cloud::Bigquery).to receive(:new).and_return(bigquery_mock)
+      allow(bigquery_mock).to receive(:query_job).and_return(job_mock)
+      allow(job_mock).to receive(:wait_until_done!)
+      allow(job_mock).to receive(:failed?).and_return(false)
+      allow(job_mock).to receive(:statistics)
 
-    expect {
-      bq_load(
-        File.join(SAMPLE_DIR, "hive_result.txt"),
+      statement = "INSERT INTO `test_dataset.test_table` (column1) SELECT column2 FROM `another_dataset.another_table`"
+      bq(
         '/path/to/bigquery_keyfile',
         'test-project',
-        'test-dataset',
-        'test-table',
-        'field1',
-        options = {
-          'fieldDelimiter' => '\t',
-          'writeDisposition' => 'WRITE_APPEND'
-        }
+        statement
       )
-    }.to raise_error(BigQueryException)
 
-    expect(job_mock).to have_received(:wait_until_done!).once
-    expect(job_mock).to have_received(:failed?).once
-    expect(job_mock).to have_received(:errors).once
+      expect(ENV.fetch('BIGQUERY_KEYFILE')).to eq('/path/to/bigquery_keyfile')
+      expect(Google::Cloud::Bigquery).to have_received(:new).with(
+        project: 'test-project',
+        retries: 3
+      ).once
+      expect(bigquery_mock).to have_received(:query_job).with(statement).once
+
+      expect(job_mock).to have_received(:wait_until_done!).once
+      expect(job_mock).to have_received(:failed?).once
+      expect(job_mock).to have_received(:statistics).once
+    end
+
+    it "should raise BigQueryException when statement is invalid" do
+      bigquery_mock = double('Google::Cloud::Bigquery mock')
+      job_mock      = double('Google::Cloud::Bigquery job mock')
+
+      allow(Google::Cloud::Bigquery).to receive(:new).and_return(bigquery_mock)
+      allow(bigquery_mock).to receive(:query_job).and_return(job_mock)
+      allow(job_mock).to receive(:wait_until_done!)
+      allow(job_mock).to receive(:failed?).and_return(true)
+      allow(job_mock).to receive(:errors).and_return("ERROR: output for test")
+
+      statement = "invalid statement"
+      begin
+        bq(
+          '/path/to/bigquery_keyfile',
+          'test-project',
+          statement
+        )
+      rescue BigQueryException => e
+      end
+
+      expect(ENV.fetch('BIGQUERY_KEYFILE')).to eq('/path/to/bigquery_keyfile')
+      expect(Google::Cloud::Bigquery).to have_received(:new).with(
+        project: 'test-project',
+        retries: 3
+      ).once
+      expect(bigquery_mock).to have_received(:query_job).with(statement).once
+
+      expect(job_mock).to have_received(:wait_until_done!).once
+      expect(job_mock).to have_received(:failed?).once
+      expect(job_mock).not_to receive(:statistics)
+    end
   end
 end


### PR DESCRIPTION
認証方式の変更により、各BigQueryアカウントで新方式の認証ファイルを取得し、iniファイルにセットする必要があります。

old.ini
```
[gcp]
service_account = sample@developer.gserviceaccount.com
private_key = /path/to/sample.p12
key_pass = secret
```

new.ini
```
[gcp]
bigquery_keyfile = /path/to/sample.json
```