### PR TITLE
Update to AWS SDK v3 for Ruby

### DIFF
--- a/plugins/patriot-aws/lib/patriot_aws/ext/aws.rb
+++ b/plugins/patriot-aws/lib/patriot_aws/ext/aws.rb
@@ -9,15 +9,17 @@ module PatriotAWS
 
       def config_aws(options)
         options.symbolize_keys
-        Aws.config.update(
-          access_key_id: options[:access_key_id],
-          secret_access_key: options[:secret_access_key]
-        )
+        Aws.config.update({
+          credentials: Aws::Credentials.new(
+            options[:access_key_id],
+            options[:secret_access_key]
+          )
+        })
 
         if options[:region]
-          Aws.config.update(
+          Aws.config.update({
             region: options[:region]
-          )
+          })
         end
       end
     end

--- a/plugins/patriot-aws/patriot-aws.gemspec
+++ b/plugins/patriot-aws/patriot-aws.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files         = Dir.glob('lib/**/*') | ['init.rb']
   s.require_paths = ['lib']
 
-  s.add_dependency 'aws-sdk', '~>2'
+  s.add_dependency 'aws-sdk', '~>3'
   s.add_dependency 'pg', '0.18.4'
   s.add_dependency 'patriot-workflow-scheduler', '~>0.7'
 end

--- a/plugins/patriot-aws/spec/patriot_aws/ext/aws_spec.rb
+++ b/plugins/patriot-aws/spec/patriot_aws/ext/aws_spec.rb
@@ -9,8 +9,11 @@ describe PatriotAWS::Ext::AWS do
         secret_access_key: 'test_secret_access_key'
       }
 
-      expect(Aws.config).to receive(:update)
-        .once.with(options.symbolize_keys)
+      expect(Aws.config).to receive(:update).once
+      expect(Aws::Credentials).to receive(:new).once.with(
+        options[:access_key_id],
+        options[:secret_access_key]
+      )
 
       config_aws(options)
     end
@@ -28,7 +31,13 @@ describe PatriotAWS::Ext::AWS do
       }
       options2 = { region: 'test_region' }
 
-      expect(Aws.config).to receive(:update).once.with(options1)
+      expect(Aws::Credentials).to receive(:new).once.with(
+        options1[:access_key_id],
+        options1[:secret_access_key]
+      )
+      expect(Aws.config).to receive(:update).once.with({
+        :credentials => anything
+      })
       expect(Aws.config).to receive(:update).once.with(options2)
 
       config_aws(options)


### PR DESCRIPTION
because AWS Signature Version 2 will be deprecated for Amazon S3
https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingAWSSDK.html